### PR TITLE
chore(auth): stabilize unified auth rollout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ ALLOWED_ORIGINS=http://localhost:3000,http://localhost:80
 DB_DRIVER=postgres
 DB_USER=root
 DB_PASSWORD=secret
-DB_SOURCE=postgresql://user:secret@0.0.0.0:5432/nostalgia?sslmode=disable
+DB_SOURCE=postgresql://root:secret@0.0.0.0:15432/nostalgia?sslmode=disable
 MIGRATION_URL=file://db/migration
 RESOURCE_PATH=./resources
 DOMAIN=http://localhost:8080
@@ -11,7 +11,7 @@ HTTP_SERVER_ADDRESS=0.0.0.0:8080
 GRPC_SERVER_ADDRESS=0.0.0.0:9090
 GRPC_GATEWAY_ADDRESS=0.0.0.0:9091
 TOKEN_SYMMETRIC_KEY=12345678901234567890123456789012
-SETUP_TOKEN=
+SETUP_TOKEN=replace-with-a-random-one-time-bootstrap-token
 ACCESS_TOKEN_DURATION=15m
 REFRESH_TOKEN_DURATION=24h
 REDIS_ADDRESS=0.0.0.0:6379

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173,http://localhost:80,
 DB_DRIVER=postgres
 DB_USER=root
 DB_PASSWORD=secret
-DB_SOURCE=postgresql://root:secret@0.0.0.0:5432/nostalgia?sslmode=disable
+DB_SOURCE=postgresql://root:secret@0.0.0.0:15432/nostalgia?sslmode=disable
 MIGRATION_URL=file://db/migration
 RESOURCE_PATH=./resources
 DOMAIN=http://localhost:8080
@@ -45,6 +45,7 @@ HTTP_SERVER_ADDRESS=0.0.0.0:8080
 GRPC_GATEWAY_ADDRESS=0.0.0.0:9091
 GRPC_SERVER_ADDRESS=0.0.0.0:9090
 TOKEN_SYMMETRIC_KEY=...
+SETUP_TOKEN=replace-with-a-random-one-time-bootstrap-token
 ACCESS_TOKEN_DURATION=15m
 REFRESH_TOKEN_DURATION=24h
 REDIS_ADDRESS=redis:6379
@@ -60,6 +61,8 @@ DEFAULT_USER_PASSWORD=123456
 DEFAULT_USER_FULLNAME=fullname
 DEFAULT_USER_EMAIL=xxx@qq.com
 ```
+
+`TOKEN_SYMMETRIC_KEY` 用于签发访问令牌，至少 32 字节；`SETUP_TOKEN` 只用于首次创建管理员账号，不是后台登录密码，也不要提交真实值。通过 Makefile 启动本地 PostgreSQL 时，宿主机端口是 `15432`；Docker Compose 内部服务仍通过 `postgres:5432` 互联。
 
 ## 🚀 快速部署
 
@@ -85,7 +88,7 @@ docker compose up --build
 | gRPC         | 9090 |
 | gRPC-Gateway | 9091 |
 | Nginx 前端     | 80   |
-| PostgreSQL   | 5432 |
+| PostgreSQL   | Docker 内部 5432；Makefile 本地映射 15432 |
 | Redis        | 6379 |
 
 #### 接口入口说明（本地docker环境）
@@ -98,6 +101,18 @@ docker compose up --build
 | RESTful API      | [http://localhost/api/](http://localhost/api/)...                                  |
 | gRPC Gateway API | [http://localhost/v1/](http://localhost/v1/)...                                    |
 | Swagger 文档       | [http://localhost/swagger/index.html](http://localhost/swagger/index.html)         |
+
+### 首次初始化管理员
+
+Nostalgia 现在使用统一的用户认证模型：公开注册用户固定为 `visitor`，后台只允许 `role = admin` 的用户访问。首次部署时通过一次性 setup 流程创建唯一管理员：
+
+1. 复制 `.env.example` 为 `.env`，设置 `TOKEN_SYMMETRIC_KEY` 和 `SETUP_TOKEN`。
+2. 启动 PostgreSQL 后运行数据库迁移。
+3. 启动 API 与前端后访问 [http://localhost/setup](http://localhost/setup)。
+4. 输入 `.env` 中的 `SETUP_TOKEN`，创建第一个管理员用户。
+5. 初始化完成后使用该账号访问 [http://localhost/admin/login](http://localhost/admin/login)。
+
+创建第一个管理员后，`/setup` 不再允许创建新的管理员；后续公开注册账号只能作为 `visitor` 使用评论等公开登录能力。
 
 ## 🧪 本地开发
 
@@ -115,7 +130,7 @@ cd nostalgia
 ```bash
 make redis # 默认镜像为 redis:7-alpine，可在 Makefile 中自行调整
 make postgres # 默认镜像为 groonga/pgroonga:3.2.3-alpine-16
-make create_db # 创建数据库
+make createdb # 创建数据库
 make migrateup # 数据库迁移
 make server # 启动 API 服务
 or
@@ -128,6 +143,8 @@ make server_docker_up # 参考 Makefile
 cd web/frontend
 bun install
 bun run dev
+bun run type-check
+bun run build
 ```
 
 ## 📮 联系与支持

--- a/docs/superpowers/plans/2026-06-10-post-auth-stabilization.md
+++ b/docs/superpowers/plans/2026-06-10-post-auth-stabilization.md
@@ -1,0 +1,277 @@
+# Post-Auth Stabilization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stabilize the auth-unification merge by documenting setup, cleaning legacy browser auth state on startup, and tightening admin login error handling.
+
+**Architecture:** Keep the backend auth model unchanged. Move frontend storage key cleanup into a small testable helper, call it during auth store initialization, and update docs/config examples to match the unified setup flow.
+
+**Tech Stack:** Vue 3, Pinia, Bun test runner, TypeScript, Go/Gin documentation and config examples.
+
+---
+
+## File Map
+
+- Create: `web/frontend/src/store/module/authStorage.ts`
+  - Owns auth storage key constants and legacy-key cleanup helpers.
+- Create: `web/frontend/src/store/module/authStorage.test.ts`
+  - Uses Bun's test runner with an in-memory storage implementation.
+- Modify: `web/frontend/src/store/module/auth.ts`
+  - Imports key constants and calls legacy-key cleanup before reading current auth state.
+- Modify: `web/frontend/src/views/admin/AdminLoginView.vue`
+  - Keeps role-denied and backend error extraction readable and safe.
+- Modify: `web/frontend/package.json`
+  - Adds a `test` script for `bun test`.
+- Modify: `README.md`
+  - Adds first-run setup and unified auth notes.
+- Modify: `.env.example`
+  - Clarifies current setup-related placeholder values.
+
+---
+
+### Task 1: Add Testable Auth Storage Cleanup
+
+**Files:**
+- Create: `web/frontend/src/store/module/authStorage.ts`
+- Create: `web/frontend/src/store/module/authStorage.test.ts`
+- Modify: `web/frontend/src/store/module/auth.ts`
+- Modify: `web/frontend/package.json`
+
+- [ ] **Step 1: Write the failing storage cleanup test**
+
+Create `web/frontend/src/store/module/authStorage.test.ts`:
+
+```ts
+import { describe, expect, test } from 'bun:test'
+import { AUTH_STORAGE_KEYS, LEGACY_AUTH_STORAGE_KEYS, cleanupLegacyAuthStorage } from './authStorage'
+
+class MemoryStorage implements Pick<Storage, 'getItem' | 'setItem' | 'removeItem' | 'key' | 'length' | 'clear'> {
+  private values = new Map<string, string>()
+
+  get length() {
+    return this.values.size
+  }
+
+  clear() {
+    this.values.clear()
+  }
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null
+  }
+
+  key(index: number) {
+    return Array.from(this.values.keys())[index] ?? null
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key)
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value)
+  }
+}
+
+describe('cleanupLegacyAuthStorage', () => {
+  test('removes legacy auth keys without removing current auth or unrelated keys', () => {
+    const storage = new MemoryStorage()
+
+    Object.values(AUTH_STORAGE_KEYS).forEach((key) => storage.setItem(key, `current:${key}`))
+    LEGACY_AUTH_STORAGE_KEYS.forEach((key) => storage.setItem(key, `legacy:${key}`))
+    storage.setItem('nostalgia-theme-mode', 'system')
+
+    cleanupLegacyAuthStorage(storage)
+
+    Object.values(AUTH_STORAGE_KEYS).forEach((key) => {
+      expect(storage.getItem(key)).toBe(`current:${key}`)
+    })
+    LEGACY_AUTH_STORAGE_KEYS.forEach((key) => {
+      expect(storage.getItem(key)).toBeNull()
+    })
+    expect(storage.getItem('nostalgia-theme-mode')).toBe('system')
+  })
+})
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+cd web/frontend && bun test src/store/module/authStorage.test.ts
+```
+
+Expected: FAIL because `authStorage.ts` does not exist.
+
+- [ ] **Step 3: Implement the storage helper**
+
+Create `web/frontend/src/store/module/authStorage.ts`:
+
+```ts
+export const AUTH_STORAGE_KEYS = {
+  TOKEN: 'nostalgia_user_token',
+  TOKEN_EXPIRES: 'nostalgia_user_token_expires_at',
+  REFRESH_TOKEN: 'nostalgia_user_refresh_token',
+  REFRESH_TOKEN_EXPIRES: 'nostalgia_user_refresh_token_expires_at',
+  USER: 'nostalgia_user_info',
+} as const
+
+export const LEGACY_AUTH_STORAGE_KEYS = [
+  'nostalgia_access_token',
+  'nostalgia_token_expires_at',
+  'nostalgia_refresh_token',
+  'nostalgia_refresh_token_expires_at',
+  'nostalgia_admin_access_token',
+  'nostalgia_admin_access_token_expires_at',
+  'nostalgia_admin_refresh_token',
+  'nostalgia_admin_refresh_token_expires_at',
+  'nostalgia_admin_user',
+] as const
+
+export type AuthStorage = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>
+
+export function cleanupLegacyAuthStorage(storage: AuthStorage = localStorage) {
+  LEGACY_AUTH_STORAGE_KEYS.forEach((key) => storage.removeItem(key))
+}
+```
+
+- [ ] **Step 4: Wire helper into the auth store**
+
+Modify `web/frontend/src/store/module/auth.ts`:
+
+```ts
+import {
+  AUTH_STORAGE_KEYS as STORAGE_KEYS,
+  LEGACY_AUTH_STORAGE_KEYS,
+  cleanupLegacyAuthStorage,
+} from '@/store/module/authStorage'
+```
+
+Remove the inline `STORAGE_KEYS` and `LEGACY_STORAGE_KEYS` constants. Call cleanup before refs read from localStorage:
+
+```ts
+export const useAuthStore = defineStore('auth', () => {
+  cleanupLegacyAuthStorage()
+
+  const token = ref(localStorage.getItem(STORAGE_KEYS.TOKEN) || '')
+```
+
+Replace `LEGACY_STORAGE_KEYS` references with `LEGACY_AUTH_STORAGE_KEYS`.
+
+- [ ] **Step 5: Add test script**
+
+Modify `web/frontend/package.json`:
+
+```json
+"test": "bun test",
+```
+
+- [ ] **Step 6: Verify GREEN**
+
+Run:
+
+```bash
+cd web/frontend && bun test src/store/module/authStorage.test.ts
+cd web/frontend && bun run type-check
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/frontend/package.json web/frontend/src/store/module/auth.ts web/frontend/src/store/module/authStorage.ts web/frontend/src/store/module/authStorage.test.ts
+git commit -m "fix(frontend): clear legacy auth storage on startup"
+```
+
+---
+
+### Task 2: Refresh Setup And Auth Documentation
+
+**Files:**
+- Modify: `README.md`
+- Modify: `.env.example`
+
+- [ ] **Step 1: Update README setup flow**
+
+Add a first-run setup section that shows:
+
+```markdown
+### 首次初始化管理员
+
+1. 在 `.env` 中设置 `TOKEN_SYMMETRIC_KEY` 和 `SETUP_TOKEN`。
+2. 运行数据库迁移。
+3. 启动服务后访问 `/setup`。
+4. 使用 `SETUP_TOKEN` 创建第一个 `admin` 用户。
+5. 后续进入 `/admin/login` 使用该账号管理内容。
+```
+
+Also mention that public registration creates only `visitor` users.
+
+- [ ] **Step 2: Update `.env.example` placeholders**
+
+Keep `SETUP_TOKEN=` present and document by value shape only:
+
+```env
+SETUP_TOKEN=replace-with-a-random-one-time-bootstrap-token
+```
+
+Do not add real secrets.
+
+- [ ] **Step 3: Verify docs diff**
+
+Run:
+
+```bash
+git diff -- README.md .env.example
+```
+
+Expected: documentation only, no secrets.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md .env.example
+git commit -m "docs(auth): document setup stabilization flow"
+```
+
+---
+
+### Task 3: Final Verification
+
+**Files:**
+- No planned source edits.
+
+- [ ] **Step 1: Run frontend verification**
+
+Run:
+
+```bash
+cd web/frontend && bun test
+cd web/frontend && bun run type-check
+cd web/frontend && bun run build
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 2: Run backend verification**
+
+Run:
+
+```bash
+make test
+```
+
+Expected: exits 0.
+
+- [ ] **Step 3: Review branch state**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline --decorate --max-count=8
+```
+
+Expected: branch is `chore/post-auth-stabilization`; working tree is clean after commits.

--- a/docs/superpowers/specs/2026-06-10-post-auth-stabilization-design.md
+++ b/docs/superpowers/specs/2026-06-10-post-auth-stabilization-design.md
@@ -1,0 +1,76 @@
+# Post-Auth Stabilization Design
+
+## Context
+
+Nostalgia now uses one user identity model for public and `/admin` traffic. Admin access is backed by `users.role = 'admin'`, public visitors use `users.role = 'visitor'`, and the first admin is created through the guarded setup flow.
+
+That migration removed a large amount of legacy admin RBAC code. The next step is not a new feature; it is a stabilization pass so deployment, local browser state, and user-facing errors match the new model.
+
+## Goals
+
+- Document the new first-run setup flow in the main README.
+- Make `.env.example` clearer about `SETUP_TOKEN` and local ports.
+- Remove legacy auth localStorage keys as soon as the frontend auth store initializes.
+- Keep `/admin/login` errors readable for owner use without exposing sensitive details.
+- Avoid changing backend auth behavior unless a small test-backed gap is found.
+- Keep this branch small enough to merge before starting CKEditor/editor parity work.
+
+## Non-Goals
+
+- No CKEditor redesign or article content style work.
+- No token model changes.
+- No new database migrations.
+- No new admin management UI.
+- No branch protection or GitHub settings work.
+
+## Frontend Storage Stabilization
+
+The auth store already writes unified user token keys:
+
+```text
+nostalgia_user_token
+nostalgia_user_token_expires_at
+nostalgia_user_refresh_token
+nostalgia_user_refresh_token_expires_at
+nostalgia_user_info
+```
+
+It also knows about legacy public/admin keys, but cleanup currently happens only when new tokens are written or the store is cleared. A returning browser can keep obsolete admin token keys until the user takes an auth action.
+
+The store should remove known legacy keys during initialization. This cleanup must not remove the new unified keys, current user info, or unrelated localStorage values such as theme mode.
+
+## Admin Login Error UX
+
+The `/admin/login` page should continue using unified `/api/users/login`. If the returned user is not `admin`, it should clear tokens and display a concise permission message.
+
+Network and backend errors should be shown as useful owner-facing messages:
+
+- non-admin account: `当前账号没有后台权限`
+- backend error text: use `error` or `message` from response data
+- unknown login failure: `管理员账号或密码不正确`
+
+No setup token, password, refresh token, or raw stack detail should be shown in the UI.
+
+## Documentation
+
+The README should describe:
+
+- `SETUP_TOKEN` as a deployment-time bootstrap secret, not a reusable admin password.
+- First-run sequence: configure env, migrate DB, start services, open `/setup`, create owner admin, then use `/admin/login`.
+- Auth model summary: registered users are `visitor`; only the setup-created owner is `admin`.
+- Frontend commands use Bun.
+
+The `.env.example` file should keep placeholder values only. It should include a comment-free, copyable `SETUP_TOKEN=` key and use the current local PostgreSQL port from the Makefile if the project has intentionally moved away from default `5432`.
+
+## Verification
+
+Minimum verification for this branch:
+
+```bash
+cd web/frontend && bun test
+cd web/frontend && bun run type-check
+cd web/frontend && bun run build
+make test
+```
+
+If `bun test` is introduced only for the storage helper, it should be fast and not require a browser.

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -8,6 +8,7 @@
     "build": "bun run type-check && bun run build-only",
     "preview": "bunx --bun vite preview",
     "build-only": "bunx --bun vite build",
+    "test": "bun test",
     "type-check": "bunx --bun vue-tsc --build --force",
     "lint": "bunx --bun eslint --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore",
     "format": "bunx --bun prettier --write src"

--- a/web/frontend/src/store/module/auth.ts
+++ b/web/frontend/src/store/module/auth.ts
@@ -4,26 +4,11 @@ import http from '@/util/http'
 import type { LoginRequest, RegisterRequest } from '@/types/request/user'
 import type { User } from '@/types/user'
 import { useUserStore } from '@/store/module/user'
-
-const STORAGE_KEYS = {
-    TOKEN: 'nostalgia_user_token',
-    TOKEN_EXPIRES: 'nostalgia_user_token_expires_at',
-    REFRESH_TOKEN: 'nostalgia_user_refresh_token',
-    REFRESH_TOKEN_EXPIRES: 'nostalgia_user_refresh_token_expires_at',
-    USER: 'nostalgia_user_info',
-} as const
-
-const LEGACY_STORAGE_KEYS = [
-    'nostalgia_access_token',
-    'nostalgia_token_expires_at',
-    'nostalgia_refresh_token',
-    'nostalgia_refresh_token_expires_at',
-    'nostalgia_admin_access_token',
-    'nostalgia_admin_access_token_expires_at',
-    'nostalgia_admin_refresh_token',
-    'nostalgia_admin_refresh_token_expires_at',
-    'nostalgia_admin_user',
-] as const
+import {
+    AUTH_STORAGE_KEYS as STORAGE_KEYS,
+    LEGACY_AUTH_STORAGE_KEYS,
+    cleanupLegacyAuthStorage,
+} from '@/store/module/authStorage'
 
 interface AuthTokens {
     access_token: string
@@ -55,6 +40,8 @@ function readStoredUser() {
 }
 
 export const useAuthStore = defineStore('auth', () => {
+    cleanupLegacyAuthStorage()
+
     const token = ref(localStorage.getItem(STORAGE_KEYS.TOKEN) || '')
     const tokenExpiresAt = ref(localStorage.getItem(STORAGE_KEYS.TOKEN_EXPIRES) || '')
     const refreshToken = ref(localStorage.getItem(STORAGE_KEYS.REFRESH_TOKEN) || '')
@@ -119,7 +106,7 @@ export const useAuthStore = defineStore('auth', () => {
         localStorage.setItem(STORAGE_KEYS.REFRESH_TOKEN, tokens.refresh_token)
         localStorage.setItem(STORAGE_KEYS.REFRESH_TOKEN_EXPIRES, tokens.refresh_token_expires_at)
 
-        LEGACY_STORAGE_KEYS.forEach((key) => localStorage.removeItem(key))
+        LEGACY_AUTH_STORAGE_KEYS.forEach((key) => localStorage.removeItem(key))
     }
 
     const updateAccessToken = (accessToken: string, expiresAt: string) => {
@@ -141,7 +128,7 @@ export const useAuthStore = defineStore('auth', () => {
             localStorage.removeItem(key)
         })
 
-        LEGACY_STORAGE_KEYS.forEach((key) => localStorage.removeItem(key))
+        LEGACY_AUTH_STORAGE_KEYS.forEach((key) => localStorage.removeItem(key))
         syncUserStore(null)
     }
 

--- a/web/frontend/src/store/module/authStorage.test.ts
+++ b/web/frontend/src/store/module/authStorage.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  AUTH_STORAGE_KEYS,
+  LEGACY_AUTH_STORAGE_KEYS,
+  cleanupLegacyAuthStorage,
+} from './authStorage'
+
+class MemoryStorage implements Pick<Storage, 'clear' | 'getItem' | 'key' | 'length' | 'removeItem' | 'setItem'> {
+  private values = new Map<string, string>()
+
+  get length() {
+    return this.values.size
+  }
+
+  clear() {
+    this.values.clear()
+  }
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null
+  }
+
+  key(index: number) {
+    return Array.from(this.values.keys())[index] ?? null
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key)
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value)
+  }
+}
+
+describe('cleanupLegacyAuthStorage', () => {
+  test('removes legacy auth keys without removing current auth or unrelated keys', () => {
+    const storage = new MemoryStorage()
+
+    Object.values(AUTH_STORAGE_KEYS).forEach((key) => storage.setItem(key, `current:${key}`))
+    LEGACY_AUTH_STORAGE_KEYS.forEach((key) => storage.setItem(key, `legacy:${key}`))
+    storage.setItem('nostalgia-theme-mode', 'system')
+
+    cleanupLegacyAuthStorage(storage)
+
+    Object.values(AUTH_STORAGE_KEYS).forEach((key) => {
+      expect(storage.getItem(key)).toBe(`current:${key}`)
+    })
+    LEGACY_AUTH_STORAGE_KEYS.forEach((key) => {
+      expect(storage.getItem(key)).toBeNull()
+    })
+    expect(storage.getItem('nostalgia-theme-mode')).toBe('system')
+  })
+})

--- a/web/frontend/src/store/module/authStorage.ts
+++ b/web/frontend/src/store/module/authStorage.ts
@@ -1,0 +1,25 @@
+export const AUTH_STORAGE_KEYS = {
+    TOKEN: 'nostalgia_user_token',
+    TOKEN_EXPIRES: 'nostalgia_user_token_expires_at',
+    REFRESH_TOKEN: 'nostalgia_user_refresh_token',
+    REFRESH_TOKEN_EXPIRES: 'nostalgia_user_refresh_token_expires_at',
+    USER: 'nostalgia_user_info',
+} as const
+
+export const LEGACY_AUTH_STORAGE_KEYS = [
+    'nostalgia_access_token',
+    'nostalgia_token_expires_at',
+    'nostalgia_refresh_token',
+    'nostalgia_refresh_token_expires_at',
+    'nostalgia_admin_access_token',
+    'nostalgia_admin_access_token_expires_at',
+    'nostalgia_admin_refresh_token',
+    'nostalgia_admin_refresh_token_expires_at',
+    'nostalgia_admin_user',
+] as const
+
+export type AuthStorage = Pick<Storage, 'removeItem'>
+
+export function cleanupLegacyAuthStorage(storage: AuthStorage = localStorage) {
+    LEGACY_AUTH_STORAGE_KEYS.forEach((key) => storage.removeItem(key))
+}

--- a/web/frontend/tsconfig.app.json
+++ b/web/frontend/tsconfig.app.json
@@ -2,7 +2,7 @@
   "extends": "@vue/tsconfig/tsconfig.dom.json",
   "include": [
     "env.d.ts", "src/**/*", "src/**/*.vue"],
-  "exclude": ["src/**/__tests__/*"],
+  "exclude": ["src/**/__tests__/*", "src/**/*.test.ts"],
   "compilerOptions": {
     "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",


### PR DESCRIPTION
## Summary
- Add post-auth stabilization spec and implementation plan.
- Clear legacy public/admin auth localStorage keys when the unified auth store starts.
- Document first-run setup, visitor/admin role model, Bun frontend commands, and local PostgreSQL port.

## Test Plan
- cd web/frontend && bun test
- make test
- cd web/frontend && bun run type-check
- cd web/frontend && bun run build