### PR TITLE
feat(frontend): align editor and reader content styles

### DIFF
--- a/docs/superpowers/plans/2026-06-10-editor-reading-parity.md
+++ b/docs/superpowers/plans/2026-06-10-editor-reading-parity.md
@@ -1,0 +1,203 @@
+# Editor Reading Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Align CKEditor authoring, public article reading, and comment rendering around one shared content style system.
+
+**Architecture:** Keep all work inside the unified `web/frontend` app. Extract CKEditor code block language options into a shared module, then tighten `content.css` so public reader output and admin editor output handle prose measure, figures, tables, images, and compact comment editing consistently.
+
+**Tech Stack:** Vue 3, TypeScript, CKEditor 5, Tailwind CSS tokens, Bun test runner, Vite.
+
+---
+
+## File Map
+
+- Create: `web/frontend/src/editor/contentLanguages.ts`
+  - Shared CKEditor code block language option list.
+- Create: `web/frontend/src/editor/contentLanguages.test.ts`
+  - Tests language coverage and duplicate prevention.
+- Modify: `web/frontend/src/admin/editor/adminEditorConfig.ts`
+  - Imports the shared language list.
+- Modify: `web/frontend/src/views/article/ArticleView.vue`
+  - Imports shared language list and applies compact prose class to the comment editor editable root.
+- Modify: `web/frontend/src/assets/content.css`
+  - Adds prose measure, CKEditor figure/table/image alignment support, and editor toolbar/content polish.
+
+---
+
+### Task 1: Shared Code Block Language Options
+
+**Files:**
+- Create: `web/frontend/src/editor/contentLanguages.test.ts`
+- Create: `web/frontend/src/editor/contentLanguages.ts`
+- Modify: `web/frontend/src/admin/editor/adminEditorConfig.ts`
+- Modify: `web/frontend/src/views/article/ArticleView.vue`
+
+- [ ] **Step 1: Write failing Bun test**
+
+Create `web/frontend/src/editor/contentLanguages.test.ts`:
+
+```ts
+import { describe, expect, test } from 'bun:test'
+import { CODE_BLOCK_LANGUAGES } from './contentLanguages'
+
+describe('CODE_BLOCK_LANGUAGES', () => {
+  test('keeps article and comment editors aligned with expected languages', () => {
+    const languages = CODE_BLOCK_LANGUAGES.map((item) => item.language)
+
+    expect(languages).toEqual([
+      'plaintext',
+      'go',
+      'python',
+      'javascript',
+      'typescript',
+      'java',
+      'c',
+      'cpp',
+      'sql',
+      'json',
+      'bash',
+      'html',
+      'css'
+    ])
+    expect(new Set(languages).size).toBe(languages.length)
+  })
+})
+```
+
+- [ ] **Step 2: Run red check**
+
+Run:
+
+```bash
+cd web/frontend && bun test src/editor/contentLanguages.test.ts
+```
+
+Expected: FAIL because `contentLanguages.ts` does not exist.
+
+- [ ] **Step 3: Implement shared module**
+
+Create `web/frontend/src/editor/contentLanguages.ts`:
+
+```ts
+export const CODE_BLOCK_LANGUAGES = [
+  { language: 'plaintext', label: 'Plain text' },
+  { language: 'go', label: 'Golang' },
+  { language: 'python', label: 'Python' },
+  { language: 'javascript', label: 'JavaScript' },
+  { language: 'typescript', label: 'TypeScript' },
+  { language: 'java', label: 'Java' },
+  { language: 'c', label: 'C' },
+  { language: 'cpp', label: 'C++' },
+  { language: 'sql', label: 'SQL' },
+  { language: 'json', label: 'JSON' },
+  { language: 'bash', label: 'Bash' },
+  { language: 'html', label: 'HTML' },
+  { language: 'css', label: 'CSS' }
+] as const
+```
+
+- [ ] **Step 4: Use the shared list**
+
+Import `CODE_BLOCK_LANGUAGES` in:
+
+```ts
+web/frontend/src/admin/editor/adminEditorConfig.ts
+web/frontend/src/views/article/ArticleView.vue
+```
+
+Replace duplicated inline `codeBlock.languages` arrays with:
+
+```ts
+languages: [...CODE_BLOCK_LANGUAGES]
+```
+
+- [ ] **Step 5: Verify**
+
+Run:
+
+```bash
+cd web/frontend && bun test src/editor/contentLanguages.test.ts
+cd web/frontend && bun run type-check
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/frontend/src/editor/contentLanguages.ts web/frontend/src/editor/contentLanguages.test.ts web/frontend/src/admin/editor/adminEditorConfig.ts web/frontend/src/views/article/ArticleView.vue
+git commit -m "refactor(frontend): share editor code block languages"
+```
+
+---
+
+### Task 2: Content CSS Parity
+
+**Files:**
+- Modify: `web/frontend/src/assets/content.css`
+- Modify: `web/frontend/src/views/article/ArticleView.vue`
+
+- [ ] **Step 1: Add prose measure and CKEditor figure support**
+
+Update `content.css` so direct text children use `--prose-measure: 72ch`, while `pre`, `figure`, and `table` keep full-width behavior. Add explicit support for CKEditor image alignment and table figures.
+
+- [ ] **Step 2: Apply compact prose to the comment editor**
+
+In `ArticleView.vue`, update `onEditorReady`:
+
+```ts
+editorInstance.ui.view.editable.element?.classList.add(
+  'reading-prose',
+  'reading-prose--compact',
+  'comment-editor-content'
+)
+```
+
+- [ ] **Step 3: Verify frontend**
+
+Run:
+
+```bash
+cd web/frontend && bun run type-check
+cd web/frontend && bun run build
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/frontend/src/assets/content.css web/frontend/src/views/article/ArticleView.vue
+git commit -m "feat(frontend): align editor and reader content styles"
+```
+
+---
+
+### Task 3: Final Verification
+
+**Files:**
+- No planned source edits.
+
+- [ ] **Step 1: Run frontend tests and build**
+
+Run:
+
+```bash
+cd web/frontend && bun test
+cd web/frontend && bun run type-check
+cd web/frontend && bun run build
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 2: Review branch state**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline --decorate --max-count=8
+```
+
+Expected: branch is `feature/editor-reading-parity`; working tree is clean after commits.

--- a/docs/superpowers/specs/2026-06-10-editor-reading-parity-design.md
+++ b/docs/superpowers/specs/2026-06-10-editor-reading-parity-design.md
@@ -1,0 +1,70 @@
+# Editor Reading Parity Design
+
+## Context
+
+The admin frontend has been migrated into `web/frontend`. The old CKEditor optimization plan still mentions `web/backend`, but the current product direction is one Vue app with public reading pages and owner-only `/admin` authoring.
+
+The current implementation already uses `reading-prose` for public article content, compact comment rendering, and the admin CKEditor editable root. The remaining problem is polish and consistency: wide editor lines can become too long, comment authoring does not use the compact prose class, and CKEditor-generated image/table figure classes need explicit public reader styling.
+
+## Goals
+
+- Make public article rendering, comment rendering, comment authoring, and admin authoring share the same prose vocabulary.
+- Keep readable line length on wide admin screens without shrinking code blocks, tables, or images.
+- Share CKEditor code block language options between admin articles and public comments.
+- Add explicit styles for CKEditor figures, image alignment classes, captions, and table wrappers.
+- Preserve the current glass archive theme while keeping article body surfaces solid and comfortable.
+
+## Non-Goals
+
+- No backend API or database changes.
+- No CKEditor package replacement.
+- No redesign of the whole admin article editor layout.
+- No visual overhaul of navigation, article cards, or theme tokens.
+- No work in removed legacy `web/backend`.
+
+## Content Styling Model
+
+`web/frontend/src/assets/content.css` remains the source of truth for authored content. The same classes should be used in all content contexts:
+
+- public article body: `reading-prose ck-content`
+- rendered comments: `reading-prose reading-prose--compact ck-content`
+- comment editor editable root: `reading-prose reading-prose--compact comment-editor-content`
+- admin article editor editable root: `reading-prose ck-content` inside `admin-editor-content`
+
+Direct textual children should use a prose measure around 72ch. Code blocks, tables, and images may use the full available width because technical content often needs horizontal space.
+
+## CKEditor Output Support
+
+The reader should intentionally style CKEditor output rather than relying only on upstream default CSS:
+
+- `figure.image`
+- `figure.table`
+- `figcaption`
+- `image-style-align-left`
+- `image-style-align-right`
+- `image-style-align-center`
+- `image-style-side`
+
+On mobile, floated image styles should collapse to full-width blocks to prevent cramped text columns.
+
+## Code Block Languages
+
+Admin article editing and public comment editing should import the same code block language list from a shared frontend module. Prism imports remain in `ArticleView.vue`, but the selectable CKEditor languages should not be duplicated.
+
+The shared list is:
+
+```text
+plaintext, go, python, javascript, typescript, java, c, cpp, sql, json, bash, html, css
+```
+
+## Verification
+
+Minimum verification:
+
+```bash
+cd web/frontend && bun test
+cd web/frontend && bun run type-check
+cd web/frontend && bun run build
+```
+
+The existing Vite large chunk warning is acceptable for this branch because CKEditor is already part of the app and this work does not increase the editor dependency surface.

--- a/web/frontend/src/admin/editor/adminEditorConfig.ts
+++ b/web/frontend/src/admin/editor/adminEditorConfig.ts
@@ -71,6 +71,7 @@ import {
   type EditorConfig
 } from 'ckeditor5'
 import translations from 'ckeditor5/translations/zh-cn.js'
+import { CODE_BLOCK_LANGUAGES } from '@/editor/contentLanguages'
 
 export const adminEditorConfig: EditorConfig = {
   toolbar: {
@@ -199,21 +200,7 @@ export const adminEditorConfig: EditorConfig = {
     ]
   },
   codeBlock: {
-    languages: [
-      { language: 'plaintext', label: 'Plain text' },
-      { language: 'go', label: 'Golang' },
-      { language: 'python', label: 'Python' },
-      { language: 'javascript', label: 'JavaScript' },
-      { language: 'typescript', label: 'TypeScript' },
-      { language: 'java', label: 'Java' },
-      { language: 'c', label: 'C' },
-      { language: 'cpp', label: 'C++' },
-      { language: 'sql', label: 'SQL' },
-      { language: 'json', label: 'JSON' },
-      { language: 'bash', label: 'Bash' },
-      { language: 'html', label: 'HTML' },
-      { language: 'css', label: 'CSS' }
-    ]
+    languages: [...CODE_BLOCK_LANGUAGES]
   },
   heading: {
     options: [

--- a/web/frontend/src/assets/content.css
+++ b/web/frontend/src/assets/content.css
@@ -1,7 +1,15 @@
 .reading-prose {
+  --prose-measure: 72ch;
+
   color: rgb(var(--color-foreground));
   overflow-wrap: break-word;
   word-break: break-word;
+}
+
+.reading-prose::after {
+  display: block;
+  clear: both;
+  content: '';
 }
 
 .reading-prose > :first-child {
@@ -181,6 +189,73 @@
   background: rgb(var(--color-border));
 }
 
+.reading-prose > :where(h1, h2, h3, h4, h5, h6, p, ul, ol, blockquote) {
+  max-width: min(100%, var(--prose-measure));
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.reading-prose > :where(pre, figure, table, hr) {
+  max-width: 100%;
+}
+
+.reading-prose figure.image {
+  text-align: center;
+}
+
+.reading-prose figure.image img {
+  width: auto;
+}
+
+.reading-prose figure.image-style-align-left {
+  margin-right: auto;
+  margin-left: 0;
+}
+
+.reading-prose figure.image-style-align-right {
+  margin-right: 0;
+  margin-left: auto;
+}
+
+.reading-prose figure.image-style-align-center {
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.reading-prose figure.image-style-side,
+.reading-prose figure.image-style-align-right {
+  float: right;
+  max-width: min(50%, 24rem);
+  margin: 0.35rem 0 1rem 1.5rem;
+}
+
+.reading-prose figure.image-style-align-left {
+  float: left;
+  max-width: min(50%, 24rem);
+  margin: 0.35rem 1.5rem 1rem 0;
+}
+
+.reading-prose figure.image-style-side img,
+.reading-prose figure.image-style-align-left img,
+.reading-prose figure.image-style-align-right img {
+  width: 100%;
+}
+
+.reading-prose figure.table {
+  display: block;
+  overflow-x: auto;
+  border-radius: 0.8rem;
+}
+
+.reading-prose figure.table table {
+  min-width: min(44rem, 100%);
+  margin: 0;
+}
+
+.reading-prose--compact {
+  --prose-measure: 58ch;
+}
+
 .reading-prose--compact h1,
 .reading-prose--compact h2,
 .reading-prose--compact h3,
@@ -204,6 +279,20 @@
   margin: 0.85rem 0;
 }
 
+.reading-prose--compact > :where(h1, h2, h3, h4, h5, h6, p, ul, ol, blockquote) {
+  margin-right: 0;
+  margin-left: 0;
+}
+
+.comment-editor-content.ck-editor__editable_inline {
+  min-height: 8rem;
+  padding: 1rem;
+}
+
+.comment-editor-content.reading-prose p {
+  margin: 0.45rem 0;
+}
+
 .admin-editor-content .ck.ck-editor {
   color: rgb(var(--color-foreground));
 }
@@ -213,14 +302,41 @@
   background: rgb(var(--color-surface-raised));
 }
 
+.admin-editor-content .ck.ck-button,
+.admin-editor-content .ck.ck-dropdown__button {
+  border-radius: 0.55rem;
+  color: rgb(var(--color-muted-foreground));
+}
+
+.admin-editor-content .ck.ck-button:hover,
+.admin-editor-content .ck.ck-dropdown__button:hover {
+  background: rgb(var(--color-muted));
+  color: rgb(var(--color-foreground));
+}
+
+.admin-editor-content .ck.ck-button.ck-on,
+.admin-editor-content .ck.ck-dropdown__button.ck-on {
+  background: rgb(var(--color-accent) / 0.14);
+  color: rgb(var(--color-accent));
+}
+
 .admin-editor-content .ck.ck-editor__main > .ck-editor__editable {
   border-color: rgb(var(--color-border));
   background: rgb(var(--color-surface));
 }
 
+.admin-editor-content .ck.ck-editor__editable.ck-focused {
+  border-color: rgb(var(--color-accent)) !important;
+  box-shadow: 0 0 0 2px rgb(var(--color-accent) / 0.18) !important;
+}
+
 .admin-editor-content .ck-content {
   min-height: 58vh;
   padding: 2rem min(3vw, 2.5rem);
+}
+
+.admin-editor-content .ck-content.reading-prose {
+  --prose-measure: 72ch;
 }
 
 .admin-editor-content .ck-content,
@@ -259,5 +375,17 @@
   .reading-prose p,
   .reading-prose li {
     font-size: 1rem;
+  }
+
+  .reading-prose figure.image-style-side,
+  .reading-prose figure.image-style-align-left,
+  .reading-prose figure.image-style-align-right {
+    float: none;
+    max-width: 100%;
+    margin: 1.25rem auto;
+  }
+
+  .admin-editor-content .ck-content {
+    padding: 1.25rem;
   }
 }

--- a/web/frontend/src/editor/contentLanguages.test.ts
+++ b/web/frontend/src/editor/contentLanguages.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test'
+import { CODE_BLOCK_LANGUAGES } from './contentLanguages'
+
+describe('CODE_BLOCK_LANGUAGES', () => {
+  test('keeps article and comment editors aligned with expected languages', () => {
+    const languages = CODE_BLOCK_LANGUAGES.map((item) => item.language)
+
+    expect(languages).toEqual([
+      'plaintext',
+      'go',
+      'python',
+      'javascript',
+      'typescript',
+      'java',
+      'c',
+      'cpp',
+      'sql',
+      'json',
+      'bash',
+      'html',
+      'css',
+    ])
+    expect(new Set(languages).size).toBe(languages.length)
+  })
+})

--- a/web/frontend/src/editor/contentLanguages.ts
+++ b/web/frontend/src/editor/contentLanguages.ts
@@ -1,0 +1,15 @@
+export const CODE_BLOCK_LANGUAGES = [
+  { language: 'plaintext', label: 'Plain text' },
+  { language: 'go', label: 'Golang' },
+  { language: 'python', label: 'Python' },
+  { language: 'javascript', label: 'JavaScript' },
+  { language: 'typescript', label: 'TypeScript' },
+  { language: 'java', label: 'Java' },
+  { language: 'c', label: 'C' },
+  { language: 'cpp', label: 'C++' },
+  { language: 'sql', label: 'SQL' },
+  { language: 'json', label: 'JSON' },
+  { language: 'bash', label: 'Bash' },
+  { language: 'html', label: 'HTML' },
+  { language: 'css', label: 'CSS' },
+] as const

--- a/web/frontend/src/views/article/ArticleView.vue
+++ b/web/frontend/src/views/article/ArticleView.vue
@@ -52,6 +52,7 @@ import AppButton from '@/components/ui/AppButton.vue'
 import AppBadge from '@/components/ui/AppBadge.vue'
 import ConfirmDialog from '@/components/ui/ConfirmDialog.vue'
 import { sanitizeHtml } from '@/util/sanitizeHtml'
+import { CODE_BLOCK_LANGUAGES } from '@/editor/contentLanguages'
 
 const router = useRouter()
 const userStore = useUserStore()
@@ -96,21 +97,7 @@ const config: Ref<EditorConfig> = ref({
   plugins: [Code, CodeBlock, Essentials, Paragraph],
   placeholder: '写下评论，Ctrl/⌘ + Enter 提交',
   codeBlock: {
-    languages: [
-      { language: 'plaintext', label: 'Plain text' },
-      { language: 'go', label: 'Golang' },
-      { language: 'python', label: 'Python' },
-      { language: 'javascript', label: 'JavaScript' },
-      { language: 'typescript', label: 'TypeScript' },
-      { language: 'java', label: 'Java' },
-      { language: 'c', label: 'C' },
-      { language: 'cpp', label: 'C++' },
-      { language: 'sql', label: 'SQL' },
-      { language: 'json', label: 'JSON' },
-      { language: 'bash', label: 'Bash' },
-      { language: 'html', label: 'HTML' },
-      { language: 'css', label: 'CSS' }
-    ]
+    languages: [...CODE_BLOCK_LANGUAGES]
   },
   language: 'zh-cn',
   translations: [translations]

--- a/web/frontend/src/views/article/ArticleView.vue
+++ b/web/frontend/src/views/article/ArticleView.vue
@@ -349,6 +349,11 @@ const updateScrollProgress = () => {
 
 const onEditorReady = (editorInstance: ClassicEditor) => {
   editor.value = editorInstance
+  editorInstance.ui.view.editable.element?.classList.add(
+    'reading-prose',
+    'reading-prose--compact',
+    'comment-editor-content'
+  )
   editorInstance.editing.view.document.on('keydown', (event: any, data: any) => {
     const domEvent = data.domEvent as KeyboardEvent
     if ((domEvent.ctrlKey || domEvent.metaKey) && domEvent.key === 'Enter') {


### PR DESCRIPTION
## Summary
- Add the current unified-frontend editor/reading parity spec and implementation plan.
- Share CKEditor code block language options between admin article editing and public comment editing.
- Align public article, rendered comment, comment editor, and admin editor content styling with prose measure and CKEditor figure/table/image support.

## Test Plan
- cd web/frontend && bun test
- cd web/frontend && bun run type-check
- cd web/frontend && bun run build