### PR TITLE
perf(frontend): lazy load public comment editor

### DIFF
--- a/docs/superpowers/plans/2026-06-10-frontend-editor-splitting.md
+++ b/docs/superpowers/plans/2026-06-10-frontend-editor-splitting.md
@@ -1,0 +1,354 @@
+# Frontend Editor Splitting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lazy-load the public comment CKEditor so visitors and passive readers do not load editor code on the article reading path.
+
+**Architecture:** Keep comment API behavior in `ArticleView.vue`, extract CKEditor rendering into a lazy `CommentEditor.vue`, and guard rendering with a small tested pure helper. Remove global CKEditor plugin registration only after local component imports cover all active editor usage.
+
+**Tech Stack:** Vue 3, TypeScript, CKEditor 5, Bun test runner, Vite.
+
+---
+
+## File Map
+
+- Create: `web/frontend/src/components/article/commentEditorGate.ts`
+  - Pure render-gating helper for public comment editor loading.
+- Create: `web/frontend/src/components/article/commentEditorGate.test.ts`
+  - Bun tests for guest, authenticated inactive, and authenticated active states.
+- Create: `web/frontend/src/components/article/CommentEditor.vue`
+  - Lazy public comment CKEditor wrapper with local CKEditor imports and submit shortcut.
+- Modify: `web/frontend/src/views/article/ArticleView.vue`
+  - Remove static CKEditor imports/config, add async component gate, and keep comment submission behavior in the parent.
+- Modify: `web/frontend/src/main.ts`
+  - Remove global `CkeditorPlugin` registration after verifying local imports work.
+
+---
+
+### Task 1: Add Editor Render Gate
+
+**Files:**
+- Create: `web/frontend/src/components/article/commentEditorGate.test.ts`
+- Create: `web/frontend/src/components/article/commentEditorGate.ts`
+
+- [ ] **Step 1: Write the failing gate test**
+
+Create `web/frontend/src/components/article/commentEditorGate.test.ts`:
+
+```ts
+import { describe, expect, test } from 'bun:test'
+import { shouldRenderCommentEditor } from './commentEditorGate'
+
+describe('shouldRenderCommentEditor', () => {
+  test('keeps the editor unloaded for guests', () => {
+    expect(shouldRenderCommentEditor({ isAuthenticated: false, isActivated: false })).toBe(false)
+    expect(shouldRenderCommentEditor({ isAuthenticated: false, isActivated: true })).toBe(false)
+  })
+
+  test('keeps the editor unloaded for authenticated passive readers', () => {
+    expect(shouldRenderCommentEditor({ isAuthenticated: true, isActivated: false })).toBe(false)
+  })
+
+  test('renders the editor only after an authenticated user activates it', () => {
+    expect(shouldRenderCommentEditor({ isAuthenticated: true, isActivated: true })).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: Run red check**
+
+Run:
+
+```bash
+cd web/frontend && bun test src/components/article/commentEditorGate.test.ts
+```
+
+Expected: FAIL because `commentEditorGate.ts` does not exist.
+
+- [ ] **Step 3: Implement the gate helper**
+
+Create `web/frontend/src/components/article/commentEditorGate.ts`:
+
+```ts
+export interface CommentEditorGateState {
+  isAuthenticated: boolean
+  isActivated: boolean
+}
+
+export const shouldRenderCommentEditor = ({
+  isAuthenticated,
+  isActivated
+}: CommentEditorGateState) => isAuthenticated && isActivated
+```
+
+- [ ] **Step 4: Run green check**
+
+Run:
+
+```bash
+cd web/frontend && bun test src/components/article/commentEditorGate.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/frontend/src/components/article/commentEditorGate.ts web/frontend/src/components/article/commentEditorGate.test.ts
+git commit -m "test(frontend): cover comment editor lazy gate"
+```
+
+### Task 2: Extract Lazy Comment Editor
+
+**Files:**
+- Create: `web/frontend/src/components/article/CommentEditor.vue`
+- Modify: `web/frontend/src/views/article/ArticleView.vue`
+
+- [ ] **Step 1: Create the lazy editor component**
+
+Create `web/frontend/src/components/article/CommentEditor.vue`:
+
+```vue
+<script setup lang="ts">
+import { computed, onMounted, ref, type Ref } from 'vue'
+import { Ckeditor } from '@ckeditor/ckeditor5-vue'
+import { ClassicEditor, Code, CodeBlock, type EditorConfig, Essentials, Paragraph } from 'ckeditor5'
+import translations from 'ckeditor5/translations/zh-cn.js'
+import 'ckeditor5/ckeditor5.css'
+import 'ckeditor5/ckeditor5-content.css'
+
+import { CODE_BLOCK_LANGUAGES } from '@/editor/contentLanguages'
+
+const props = withDefaults(
+  defineProps<{
+    modelValue: string
+    disabled?: boolean
+  }>(),
+  {
+    disabled: false
+  }
+)
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+  submit: []
+}>()
+
+const editorData = computed({
+  get: () => props.modelValue,
+  set: (value: string) => emit('update:modelValue', value)
+})
+
+const isLayoutReady = ref(false)
+
+const config: Ref<EditorConfig> = ref({
+  toolbar: {
+    items: ['undo', 'redo', '|', 'code', 'codeBlock'],
+    shouldNotGroupWhenFull: true
+  },
+  plugins: [Code, CodeBlock, Essentials, Paragraph],
+  placeholder: '写下评论，Ctrl/⌘ + Enter 提交',
+  codeBlock: {
+    languages: [...CODE_BLOCK_LANGUAGES]
+  },
+  language: 'zh-cn',
+  translations: [translations]
+})
+
+const onEditorReady = (editorInstance: ClassicEditor) => {
+  editorInstance.ui.view.editable.element?.classList.add(
+    'reading-prose',
+    'reading-prose--compact',
+    'comment-editor-content'
+  )
+  editorInstance.editing.view.document.on('keydown', (event: unknown, data: any) => {
+    const domEvent = data.domEvent as KeyboardEvent
+    if ((domEvent.ctrlKey || domEvent.metaKey) && domEvent.key === 'Enter') {
+      data.preventDefault()
+      ;(event as { stop: () => void }).stop()
+      emit('submit')
+    }
+  })
+}
+
+onMounted(() => {
+  isLayoutReady.value = true
+})
+</script>
+
+<template>
+  <div id="comment-editor" class="overflow-hidden rounded-archive border border-border">
+    <Ckeditor
+      v-if="isLayoutReady"
+      v-model="editorData"
+      :editor="ClassicEditor"
+      :config="config"
+      :disabled="disabled"
+      @ready="onEditorReady"
+    />
+  </div>
+</template>
+
+<style scoped>
+:deep(.ck-editor__editable_inline) {
+  min-height: 8rem;
+  background: rgb(var(--color-surface));
+  color: rgb(var(--color-foreground));
+}
+
+:deep(.ck-toolbar) {
+  background: rgb(var(--color-surface-raised)) !important;
+  border-color: rgb(var(--color-border)) !important;
+}
+
+:deep(.ck-content) {
+  background: rgb(var(--color-surface)) !important;
+}
+</style>
+```
+
+- [ ] **Step 2: Wire the async component in `ArticleView.vue`**
+
+In `ArticleView.vue`, remove direct CKEditor imports and replace them with:
+
+```ts
+import { computed, defineAsyncComponent, nextTick, onMounted, onUnmounted, onUpdated, provide, ref } from 'vue'
+import { shouldRenderCommentEditor } from '@/components/article/commentEditorGate'
+
+const CommentEditor = defineAsyncComponent(() => import('@/components/article/CommentEditor.vue'))
+const isCommentEditorActive = ref(false)
+const canRenderCommentEditor = computed(() =>
+  shouldRenderCommentEditor({
+    isAuthenticated: Boolean(userStore.userInfo),
+    isActivated: isCommentEditorActive.value
+  })
+)
+```
+
+Replace the old `onEditorReady`, editor config, editor ref, and manual editor destroy logic with parent-owned activation:
+
+```ts
+const scrollToCommentEditor = async () => {
+  await nextTick()
+  document.getElementById('comment-editor')?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+}
+
+const activateCommentEditor = async () => {
+  if (!userStore.userInfo) {
+    toast.add({
+      severity: 'info',
+      summary: '需要登录',
+      detail: '登录后才能使用评论功能',
+      life: 2500
+    })
+    return false
+  }
+
+  isCommentEditorActive.value = true
+  await scrollToCommentEditor()
+  return true
+}
+```
+
+Update logged-in comment template to render a lightweight activation state until `canRenderCommentEditor` is true. Once true, render:
+
+```vue
+<CommentEditor
+  v-model="editorData"
+  :disabled="isSubmittingComment"
+  @submit="createComment(0, article.owner)"
+/>
+```
+
+- [ ] **Step 3: Preserve reply behavior**
+
+Update `replyComment` so the unauthenticated path keeps the existing login toast, cancel reply still clears state, and logged-in reply activates the editor before scrolling:
+
+```ts
+isCommentEditorActive.value = true
+replyCommentId.value = commentId
+replyUserName.value = `@${toUserName}`
+replyUserId.value = toUserId
+replyCommentParentId.value = parentId === 0 ? commentId : parentId
+void scrollToCommentEditor()
+```
+
+- [ ] **Step 4: Run type check**
+
+Run:
+
+```bash
+cd web/frontend && bun run type-check
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/frontend/src/components/article/CommentEditor.vue web/frontend/src/views/article/ArticleView.vue
+git commit -m "perf(frontend): lazy load public comment editor"
+```
+
+### Task 3: Remove Global CKEditor Registration
+
+**Files:**
+- Modify: `web/frontend/src/main.ts`
+
+- [ ] **Step 1: Remove global plugin import and registration**
+
+In `web/frontend/src/main.ts`, delete:
+
+```ts
+import { CkeditorPlugin } from '@ckeditor/ckeditor5-vue'
+app.use(CkeditorPlugin)
+```
+
+- [ ] **Step 2: Verify active editors still compile**
+
+Run:
+
+```bash
+cd web/frontend && bun run type-check
+cd web/frontend && bun run build
+```
+
+Expected: PASS. The admin editor and lazy comment editor both import `Ckeditor` locally.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/frontend/src/main.ts
+git commit -m "perf(frontend): remove global ckeditor registration"
+```
+
+### Task 4: Final Verification and PR
+
+**Files:**
+- Verify changed files only; no new production files expected.
+
+- [ ] **Step 1: Run full frontend checks**
+
+Run:
+
+```bash
+cd web/frontend && bun test
+cd web/frontend && bun run type-check
+cd web/frontend && bun run build
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 2: Inspect bundle output**
+
+Check the Vite output from `bun run build`. Expected: public article code no longer directly imports CKEditor, and the build output contains a separate async component/editor chunk.
+
+- [ ] **Step 3: Push and open PR**
+
+Run:
+
+```bash
+git status --short --branch
+git push -u origin perf/frontend-editor-splitting
+gh pr create --base master --head perf/frontend-editor-splitting --title "perf(frontend): lazy load public comment editor" --body-file /tmp/nostalgia-frontend-editor-splitting-pr.md
+```

--- a/docs/superpowers/specs/2026-06-10-frontend-editor-splitting-design.md
+++ b/docs/superpowers/specs/2026-06-10-frontend-editor-splitting-design.md
@@ -1,0 +1,71 @@
+# Frontend Editor Splitting Design
+
+## Context
+
+The unified Vue frontend now serves both public reading pages and the owner-only `/admin` area. CKEditor is required for article authoring and authenticated commenting, but the public article page currently imports CKEditor directly. That makes reader traffic pay for editor code even when a visitor only reads an article or is not logged in.
+
+This branch reduces the public reader path by moving the comment editor behind a lazy boundary. Admin authoring stays unchanged except for removing any unnecessary global CKEditor registration from the app entry when local component imports already cover editor usage.
+
+## Goals
+
+- Remove CKEditor and CKEditor CSS imports from `ArticleView.vue`.
+- Load the public comment editor only when a logged-in user explicitly activates the comment box or starts a reply.
+- Keep guests on a lightweight login/register prompt without loading the comment editor.
+- Preserve current comment behavior: empty-content validation, reply targeting, cancel reply, submit button state, `Ctrl/Cmd + Enter`, Chinese placeholder, code/codeBlock tools, and shared code block language list.
+- Keep admin editor functionality intact.
+- Make the bundle split visible in Vite output with CKEditor code isolated away from the public article route module.
+
+## Non-Goals
+
+- No backend API changes.
+- No database or migration changes.
+- No CKEditor version upgrade.
+- No replacement of CKEditor.
+- No visual redesign of comments beyond the small activation state needed for lazy loading.
+- No removal of the legacy `EditorView.vue` file unless it is separately proven unused and approved.
+
+## Design
+
+### Lazy Comment Editor
+
+Create `web/frontend/src/components/article/CommentEditor.vue` as the only public-comment component that imports:
+
+- `@ckeditor/ckeditor5-vue`
+- `ckeditor5`
+- `ckeditor5/translations/zh-cn.js`
+- `ckeditor5/ckeditor5.css`
+- `ckeditor5/ckeditor5-content.css`
+
+`ArticleView.vue` imports this component through `defineAsyncComponent`. Because the component is rendered only behind an authenticated-and-activated gate, guests and passive readers should not fetch the CKEditor chunk.
+
+### Activation Gate
+
+Add a small pure helper in `web/frontend/src/components/article/commentEditorGate.ts`:
+
+- authenticated + active: render the lazy editor.
+- authenticated + inactive: render a lightweight "write comment" action.
+- guest: render the existing login/register prompt.
+
+`ArticleView.vue` owns the activation state. Clicking the write-comment action activates the editor. Clicking reply while logged in also activates it, preserves reply metadata, and scrolls to the editor after the DOM updates.
+
+### Comment Flow
+
+`CommentEditor.vue` receives `modelValue` and `disabled`, emits `update:modelValue`, and emits `submit` when the user presses `Ctrl/Cmd + Enter`. `ArticleView.vue` keeps comment submission, reply resolution, store calls, toast messages, and comment-list mutation in the parent so API behavior remains unchanged.
+
+After a successful submission, `ArticleView.vue` clears `editorData` and resets reply state as it does today. The editor may remain active so the logged-in user can continue writing without paying the lazy-load cost again.
+
+### App Entry
+
+Remove the global `CkeditorPlugin` registration from `web/frontend/src/main.ts` if the build and type-check show local component imports are sufficient. Admin editor already imports `Ckeditor` locally, and the public lazy editor will also import it locally.
+
+### Verification
+
+Minimum verification:
+
+```bash
+cd web/frontend && bun test
+cd web/frontend && bun run type-check
+cd web/frontend && bun run build
+```
+
+The build output should show a separate async editor-related chunk instead of keeping the public article module tied to direct CKEditor imports. A remaining large-chunk warning is acceptable if the main reader path is reduced and editor code is split.

--- a/web/frontend/src/components/article/CommentEditor.vue
+++ b/web/frontend/src/components/article/CommentEditor.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, type Ref } from 'vue'
+import { Ckeditor } from '@ckeditor/ckeditor5-vue'
+import { ClassicEditor, Code, CodeBlock, type EditorConfig, Essentials, Paragraph } from 'ckeditor5'
+import translations from 'ckeditor5/translations/zh-cn.js'
+import 'ckeditor5/ckeditor5.css'
+import 'ckeditor5/ckeditor5-content.css'
+
+import { CODE_BLOCK_LANGUAGES } from '@/editor/contentLanguages'
+
+const props = withDefaults(
+  defineProps<{
+    modelValue: string
+    disabled?: boolean
+  }>(),
+  {
+    disabled: false
+  }
+)
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+  submit: []
+}>()
+
+const editorData = computed({
+  get: () => props.modelValue,
+  set: (value: string) => emit('update:modelValue', value)
+})
+
+const isLayoutReady = ref(false)
+
+const config: Ref<EditorConfig> = ref({
+  toolbar: {
+    items: ['undo', 'redo', '|', 'code', 'codeBlock'],
+    shouldNotGroupWhenFull: true
+  },
+  plugins: [Code, CodeBlock, Essentials, Paragraph],
+  placeholder: '写下评论，Ctrl/⌘ + Enter 提交',
+  codeBlock: {
+    languages: [...CODE_BLOCK_LANGUAGES]
+  },
+  language: 'zh-cn',
+  translations: [translations]
+})
+
+const onEditorReady = (editorInstance: ClassicEditor) => {
+  editorInstance.ui.view.editable.element?.classList.add(
+    'reading-prose',
+    'reading-prose--compact',
+    'comment-editor-content'
+  )
+  editorInstance.editing.view.document.on('keydown', (event: unknown, data: unknown) => {
+    const keyEvent = event as { stop: () => void }
+    const keyData = data as { domEvent: KeyboardEvent; preventDefault: () => void }
+
+    if ((keyData.domEvent.ctrlKey || keyData.domEvent.metaKey) && keyData.domEvent.key === 'Enter') {
+      keyData.preventDefault()
+      keyEvent.stop()
+      emit('submit')
+    }
+  })
+}
+
+onMounted(() => {
+  isLayoutReady.value = true
+})
+</script>
+
+<template>
+  <div id="comment-editor" class="overflow-hidden rounded-archive border border-border">
+    <Ckeditor
+      v-if="isLayoutReady"
+      v-model="editorData"
+      :editor="ClassicEditor"
+      :config="config"
+      :disabled="disabled"
+      @ready="onEditorReady"
+    />
+  </div>
+</template>
+
+<style scoped>
+:deep(.ck-editor__editable_inline) {
+  min-height: 8rem;
+  background: rgb(var(--color-surface));
+  color: rgb(var(--color-foreground));
+}
+
+:deep(.ck-toolbar) {
+  background: rgb(var(--color-surface-raised)) !important;
+  border-color: rgb(var(--color-border)) !important;
+}
+
+:deep(.ck-content) {
+  background: rgb(var(--color-surface)) !important;
+}
+</style>

--- a/web/frontend/src/components/article/CommentEditor.vue
+++ b/web/frontend/src/components/article/CommentEditor.vue
@@ -54,7 +54,10 @@ const onEditorReady = (editorInstance: ClassicEditor) => {
     const keyEvent = event as { stop: () => void }
     const keyData = data as { domEvent: KeyboardEvent; preventDefault: () => void }
 
-    if ((keyData.domEvent.ctrlKey || keyData.domEvent.metaKey) && keyData.domEvent.key === 'Enter') {
+    if (
+      (keyData.domEvent.ctrlKey || keyData.domEvent.metaKey) &&
+      keyData.domEvent.key === 'Enter'
+    ) {
       keyData.preventDefault()
       keyEvent.stop()
       emit('submit')

--- a/web/frontend/src/components/article/commentEditorGate.test.ts
+++ b/web/frontend/src/components/article/commentEditorGate.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'bun:test'
+import { shouldRenderCommentEditor } from './commentEditorGate'
+
+describe('shouldRenderCommentEditor', () => {
+  test('keeps the editor unloaded for guests', () => {
+    expect(shouldRenderCommentEditor({ isAuthenticated: false, isActivated: false })).toBe(false)
+    expect(shouldRenderCommentEditor({ isAuthenticated: false, isActivated: true })).toBe(false)
+  })
+
+  test('keeps the editor unloaded for authenticated passive readers', () => {
+    expect(shouldRenderCommentEditor({ isAuthenticated: true, isActivated: false })).toBe(false)
+  })
+
+  test('renders the editor only after an authenticated user activates it', () => {
+    expect(shouldRenderCommentEditor({ isAuthenticated: true, isActivated: true })).toBe(true)
+  })
+})

--- a/web/frontend/src/components/article/commentEditorGate.ts
+++ b/web/frontend/src/components/article/commentEditorGate.ts
@@ -1,0 +1,9 @@
+export interface CommentEditorGateState {
+  isAuthenticated: boolean
+  isActivated: boolean
+}
+
+export const shouldRenderCommentEditor = ({
+  isAuthenticated,
+  isActivated
+}: CommentEditorGateState) => isAuthenticated && isActivated

--- a/web/frontend/src/main.ts
+++ b/web/frontend/src/main.ts
@@ -9,8 +9,6 @@ import { createPinia } from 'pinia'
 import VueAxios from 'vue-axios'
 import axios from 'axios'
 
-import { CkeditorPlugin } from '@ckeditor/ckeditor5-vue'
-
 import dayjs from 'dayjs'
 import localData from 'dayjs/plugin/localeData'
 import { initTheme } from '@/composables/useTheme'
@@ -26,8 +24,6 @@ app.use(router)
 
 app.use(VueAxios, axios as any)
 axios.defaults.baseURL = import.meta.env.VITE_APP_BASE_URL
-
-app.use(CkeditorPlugin)
 
 dayjs.extend(localData)
 

--- a/web/frontend/src/views/article/ArticleView.vue
+++ b/web/frontend/src/views/article/ArticleView.vue
@@ -1,5 +1,14 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, onUpdated, provide, ref, type Ref } from 'vue'
+import {
+  computed,
+  defineAsyncComponent,
+  nextTick,
+  onMounted,
+  onUnmounted,
+  onUpdated,
+  provide,
+  ref
+} from 'vue'
 import { useRouter } from 'vue-router'
 import {
   AlertTriangle,
@@ -13,11 +22,6 @@ import {
   Link as LinkIcon,
   ShieldCheck
 } from '@lucide/vue'
-import { Ckeditor } from '@ckeditor/ckeditor5-vue'
-import { ClassicEditor, Code, CodeBlock, type EditorConfig, Essentials, Paragraph } from 'ckeditor5'
-import translations from 'ckeditor5/translations/zh-cn.js'
-import 'ckeditor5/ckeditor5.css'
-import 'ckeditor5/ckeditor5-content.css'
 
 import Prism from 'prismjs'
 import 'prismjs/components/prism-bash.min.js'
@@ -52,12 +56,13 @@ import AppButton from '@/components/ui/AppButton.vue'
 import AppBadge from '@/components/ui/AppBadge.vue'
 import ConfirmDialog from '@/components/ui/ConfirmDialog.vue'
 import { sanitizeHtml } from '@/util/sanitizeHtml'
-import { CODE_BLOCK_LANGUAGES } from '@/editor/contentLanguages'
+import { shouldRenderCommentEditor } from '@/components/article/commentEditorGate'
 
 const router = useRouter()
 const userStore = useUserStore()
 const commentStore = useCommentStore()
 const toast = useToast()
+const CommentEditor = defineAsyncComponent(() => import('@/components/article/CommentEditor.vue'))
 
 const props = defineProps<{
   id: string
@@ -65,10 +70,9 @@ const props = defineProps<{
 
 const articlePath = ref(window.location.href)
 const articleId = ref(props.id)
-const editor = ref<ClassicEditor>()
 const editorData = ref('')
 const isSubmittingComment = ref(false)
-const isLayoutReady = ref(false)
+const isCommentEditorActive = ref(false)
 const article = ref<Article | null>(null)
 const comments = ref<ArticleComments[]>([])
 
@@ -81,6 +85,12 @@ const deleteDialogOpen = ref(false)
 const pendingDeleteId = ref<number | null>(null)
 const sanitizedArticleContent = computed(() => sanitizeHtml(article.value?.content || ''))
 const isArticlePathCopied = ref(false)
+const canRenderCommentEditor = computed(() =>
+  shouldRenderCommentEditor({
+    isAuthenticated: Boolean(userStore.userInfo),
+    isActivated: isCommentEditorActive.value
+  })
+)
 
 const scrollProgress = ref(0)
 const viewed = ref(false)
@@ -89,19 +99,28 @@ const isOutdated = ref(false)
 let timer: ReturnType<typeof setTimeout>
 let copyTimer: ReturnType<typeof setTimeout> | undefined
 
-const config: Ref<EditorConfig> = ref({
-  toolbar: {
-    items: ['undo', 'redo', '|', 'code', 'codeBlock'],
-    shouldNotGroupWhenFull: true
-  },
-  plugins: [Code, CodeBlock, Essentials, Paragraph],
-  placeholder: '写下评论，Ctrl/⌘ + Enter 提交',
-  codeBlock: {
-    languages: [...CODE_BLOCK_LANGUAGES]
-  },
-  language: 'zh-cn',
-  translations: [translations]
-})
+const scrollToCommentEditor = async () => {
+  await nextTick()
+  document
+    .getElementById('comment-editor')
+    ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+}
+
+const activateCommentEditor = async () => {
+  if (!userStore.userInfo) {
+    toast.add({
+      severity: 'info',
+      summary: '需要登录',
+      detail: '登录后才能使用评论功能',
+      life: 2500
+    })
+    return false
+  }
+
+  isCommentEditorActive.value = true
+  await scrollToCommentEditor()
+  return true
+}
 
 const replyComment = (
   commentId: number,
@@ -127,11 +146,12 @@ const replyComment = (
     return
   }
 
-  document.getElementById('editor')?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  isCommentEditorActive.value = true
   replyCommentId.value = commentId
   replyUserName.value = `@${toUserName}`
   replyUserId.value = toUserId
   replyCommentParentId.value = parentId === 0 ? commentId : parentId
+  void scrollToCommentEditor()
 }
 
 const removeCommentFromTree = (list: ArticleComments[], targetId: number): boolean => {
@@ -347,23 +367,6 @@ const updateScrollProgress = () => {
   scrollProgress.value = height > 0 ? (winScroll / height) * 100 : 0
 }
 
-const onEditorReady = (editorInstance: ClassicEditor) => {
-  editor.value = editorInstance
-  editorInstance.ui.view.editable.element?.classList.add(
-    'reading-prose',
-    'reading-prose--compact',
-    'comment-editor-content'
-  )
-  editorInstance.editing.view.document.on('keydown', (event: any, data: any) => {
-    const domEvent = data.domEvent as KeyboardEvent
-    if ((domEvent.ctrlKey || domEvent.metaKey) && domEvent.key === 'Enter') {
-      data.preventDefault()
-      event.stop()
-      createComment(0, article.value?.owner || '')
-    }
-  })
-}
-
 onUpdated(() => {
   Prism.highlightAll()
 })
@@ -394,7 +397,6 @@ onMounted(async () => {
     }
   }
 
-  isLayoutReady.value = true
   window.addEventListener('scroll', updateScrollProgress)
   timer = setTimeout(() => {
     checkValidView()
@@ -405,7 +407,6 @@ onUnmounted(() => {
   clearTimeout(timer)
   if (copyTimer) clearTimeout(copyTimer)
   window.removeEventListener('scroll', updateScrollProgress)
-  if (editor.value) editor.value.destroy()
 })
 </script>
 
@@ -519,14 +520,21 @@ onUnmounted(() => {
       <h2 class="m-0 text-xl font-black">评论</h2>
 
       <div v-if="userStore.userInfo" class="mt-4">
-        <div id="editor" class="overflow-hidden rounded-archive border border-border">
-          <ckeditor
-            v-if="isLayoutReady"
-            v-model="editorData"
-            :editor="ClassicEditor"
-            :config="config"
-            @ready="onEditorReady"
-          />
+        <CommentEditor
+          v-if="canRenderCommentEditor"
+          v-model="editorData"
+          :disabled="isSubmittingComment"
+          @submit="createComment(0, article.owner)"
+        />
+        <div
+          v-else
+          class="flex flex-col gap-3 rounded-archive border border-border bg-surface-raised p-5 sm:flex-row sm:items-center sm:justify-between"
+        >
+          <div>
+            <p class="m-0 text-sm font-black text-foreground">参与讨论</p>
+            <p class="m-0 mt-1 text-sm text-muted-foreground">写下你的想法，和这篇文章接上话。</p>
+          </div>
+          <AppButton size="sm" class="w-max" @click="activateCommentEditor">写评论</AppButton>
         </div>
         <div class="mt-3 flex items-center justify-between gap-3">
           <span class="text-sm font-semibold text-muted-foreground">{{ replyUserName }}</span>
@@ -589,20 +597,3 @@ onUnmounted(() => {
     @confirm="confirmDeleteComment"
   />
 </template>
-
-<style scoped>
-:deep(.ck-editor__editable_inline) {
-  min-height: 8rem;
-  background: rgb(var(--color-surface));
-  color: rgb(var(--color-foreground));
-}
-
-:deep(.ck-toolbar) {
-  background: rgb(var(--color-surface-raised)) !important;
-  border-color: rgb(var(--color-border)) !important;
-}
-
-:deep(.ck-content) {
-  background: rgb(var(--color-surface)) !important;
-}
-</style>

--- a/web/frontend/src/views/article/ArticleView.vue
+++ b/web/frontend/src/views/article/ArticleView.vue
@@ -98,12 +98,24 @@ const liked = ref(false)
 const isOutdated = ref(false)
 let timer: ReturnType<typeof setTimeout>
 let copyTimer: ReturnType<typeof setTimeout> | undefined
+const COMMENT_EDITOR_SCROLL_ATTEMPTS = 20
+const COMMENT_EDITOR_SCROLL_DELAY_MS = 50
 
-const scrollToCommentEditor = async () => {
+const waitForCommentEditorMount = () =>
+  new Promise((resolve) => window.setTimeout(resolve, COMMENT_EDITOR_SCROLL_DELAY_MS))
+
+const scrollToCommentEditor = async (attempt = 0): Promise<void> => {
   await nextTick()
-  document
-    .getElementById('comment-editor')
-    ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  const editorElement = document.getElementById('comment-editor')
+  if (editorElement) {
+    editorElement.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    return
+  }
+
+  if (attempt >= COMMENT_EDITOR_SCROLL_ATTEMPTS) return
+
+  await waitForCommentEditorMount()
+  return scrollToCommentEditor(attempt + 1)
 }
 
 const activateCommentEditor = async () => {


### PR DESCRIPTION
## Summary
- Lazy-load the public comment CKEditor behind an authenticated activation gate.
- Move comment CKEditor imports/CSS into a dedicated async CommentEditor component.
- Remove global CKEditor plugin registration from the app entry.
- Add Bun tests for the comment editor render gate and docs for the implementation plan.

## Test Plan
- `cd web/frontend && bun test` (13 pass)
- `cd web/frontend && bun run type-check`
- `cd web/frontend && bun run build`

## Bundle Notes
- Public entry chunk is now about 768 kB minified / 285 kB gzip in the Vite build output.
- CommentEditor is emitted as its own async JS/CSS chunk.
- CKEditor shared code is split into an async editor-related chunk; the existing large chunk warning remains.