### PR TITLE
ci: cover frontend and compose checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,56 +1,65 @@
-name: Run unit tests
+name: Run tests
 
 on:
   push:
     branches: [ master ]
-    paths-ignore:
-      - 'web/**'
   pull_request:
     branches: [ master ]
-    paths-ignore:
-      - 'web/**'
 
 jobs:
-  test:
+  backend:
     name: Test
     runs-on: ubuntu-latest
 
     env:
-      ENV_PASSPHRASE: ${{ secrets.ENV_PASSPHRASE }}
+      ENVIRONMENT: test
+      ALLOWED_ORIGINS: http://localhost
+      DB_DRIVER: postgres
+      DB_USER: root
+      DB_PASSWORD: secret
+      DB_SOURCE: postgresql://root:secret@localhost:5432/nostalgia?sslmode=disable
+      DB_URL: postgresql://root:secret@localhost:5432/nostalgia?sslmode=disable
+      MIGRATION_URL: file://db/migration
+      RESOURCE_PATH: ./resources
+      DOMAIN: http://localhost:8080
+      HTTP_SERVER_ADDRESS: 0.0.0.0:8080
+      GRPC_GATEWAY_ADDRESS: 0.0.0.0:9091
+      GRPC_SERVER_ADDRESS: 0.0.0.0:9090
+      TOKEN_SYMMETRIC_KEY: 12345678901234567890123456789012
+      SETUP_TOKEN: ci-setup-token
+      ACCESS_TOKEN_DURATION: 15m
+      REFRESH_TOKEN_DURATION: 24h
+      REDIS_ADDRESS: localhost:6379
+      EMAIL_SENDER_NAME: Nostalgia CI
+      EMAIL_SENDER_ADDRESS: noreply@example.com
+      EMAIL_SENDER_PASSWORD: ci-mail-password
+      UPLOAD_FILE_SIZE_LIMIT: "5242880"
+      UPLOAD_FILE_ALLOWED_MIME: image/jpeg,image/png
+      HTTP_PROXY_ADDR: ""
 
-    # Service containers to run with `container-job`
     services:
-      # Label used to access the service container
       postgres:
-        # Docker Hub image
         image: groonga/pgroonga:3.2.3-alpine-16
-        # Provide the password for postgres
         env:
-          POSTGRES_USER: ${{ secrets.DB_USER }}
-          POSTGRES_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          POSTGRES_USER: root
+          POSTGRES_PASSWORD: secret
           POSTGRES_DB: nostalgia
-        # Set health checks to wait until postgres has started
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U root -d nostalgia"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
         ports:
-          # Maps tcp port 5432 on service container to the host
           - 5432:5432
+
     steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: 1.24.x
-        id: go
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: Decrypt ENV
-        run: |
-          make decrypt_env env=dev
 
       - name: Install golang-migrate
         run: |
@@ -59,9 +68,51 @@ jobs:
           which migrate
 
       - name: Run migrations
-        env:
-          DB_URL: postgresql://${{ secrets.DB_USER }}:${{ secrets.DB_PASSWORD }}@localhost:5432/nostalgia?sslmode=disable
         run: make migrateup
 
-      - name: Test
+      - name: Run backend tests
         run: make test
+
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        working-directory: web/frontend
+        run: bun install --frozen-lockfile
+
+      - name: Run frontend tests
+        working-directory: web/frontend
+        run: bun test
+
+      - name: Run type check
+        working-directory: web/frontend
+        run: bun run type-check
+
+      - name: Build frontend
+        working-directory: web/frontend
+        run: bun run build
+
+  compose-config:
+    name: Compose Config
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Prepare compose environment
+        run: cp .env.example .env
+
+      - name: Validate production compose config
+        run: docker compose config --quiet
+
+      - name: Validate development compose config
+        run: docker compose -f docker-compose.dev.yaml config --quiet

--- a/docs/superpowers/plans/2026-06-11-platform-hardening-roadmap.md
+++ b/docs/superpowers/plans/2026-06-11-platform-hardening-roadmap.md
@@ -1,0 +1,199 @@
+# Platform Hardening Roadmap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the six identified optimization areas into a tracked roadmap and begin with CI coverage hardening.
+
+**Architecture:** Treat each optimization as an independently shippable phase. The first branch upgrades GitHub Actions so backend, frontend, and deployment config regressions are caught before later performance, security, health-check, and database cleanup work lands.
+
+**Tech Stack:** GitHub Actions, Go, PostgreSQL service containers, Bun, Vite, Docker Compose, Nginx, Vue.
+
+---
+
+## Roadmap Phases
+
+1. **CI workflow coverage and env cleanup**
+   - Run backend tests on every PR and push to `master`.
+   - Run frontend `bun test`, `bun run type-check`, and `bun run build`.
+   - Run `docker compose config --quiet` for production and dev compose files.
+   - Stop decrypting `.env.dev.enc` in CI; use explicit CI environment variables instead.
+
+2. **Frontend bundle splitting**
+   - Split CKEditor, Prism/content rendering, and admin editor chunks with Vite `manualChunks`.
+   - Keep route-level lazy loading for admin/editor surfaces.
+   - Add build/config guard tests so large editor dependencies do not re-enter the public entry chunk.
+
+3. **Frontend XSS and CSP hardening**
+   - Centralize rich-text sanitization policy.
+   - Add tests for dangerous HTML, URL protocols, and article/comment rendering.
+   - Add a baseline Nginx Content-Security-Policy compatible with CKEditor output and uploaded resources.
+   - Remove stray production `console.log` calls.
+
+4. **Health checks and deployment observability**
+   - Add API `/healthz` and `/readyz` endpoints.
+   - Add Docker Compose healthchecks for `api`, `web`, `postgres`, and `redis`.
+   - Add Nginx routing for health endpoints and document expected operational signals.
+
+5. **Database legacy structure audit**
+   - Audit migrations, generated sqlc code, queries, docs, and frontend assumptions for old admin/RBAC tables.
+   - Remove unreachable legacy code only after confirming no migration/data path depends on it.
+   - Document any manual data review needed before destructive migrations.
+
+6. **Deployment and build polish**
+   - Add Docker BuildKit registry cache when the registry supports it.
+   - Add image labels and build metadata.
+   - Consider `docker/build-push-action` after the plain shell workflow is stable.
+
+## Phase 1 File Structure
+
+- Modify `.github/workflows/test.yml`: split backend/frontend/compose jobs and remove `make decrypt_env env=dev`.
+- Modify `web/frontend/src/deploy/nginxConfig.test.ts`: add CI workflow guard tests.
+- Modify docs if verification commands or CI expectations change.
+
+## Phase 1 Tasks
+
+### Task 1: Add CI Workflow Guard Tests
+
+**Files:**
+- Modify: `web/frontend/src/deploy/nginxConfig.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests that assert `.github/workflows/test.yml`:
+
+```ts
+expect(workflow).not.toContain('paths-ignore:')
+expect(workflow).not.toContain('make decrypt_env env=dev')
+expect(workflow).toContain('bun test')
+expect(workflow).toContain('bun run type-check')
+expect(workflow).toContain('bun run build')
+expect(workflow).toContain('docker compose config --quiet')
+expect(workflow).toContain('docker compose -f docker-compose.dev.yaml config --quiet')
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd web/frontend && bun test src/deploy/nginxConfig.test.ts
+```
+
+Expected: FAIL because current workflow ignores `web/**`, decrypts env, and lacks frontend/compose jobs.
+
+### Task 2: Refactor Test Workflow
+
+**Files:**
+- Modify: `.github/workflows/test.yml`
+
+- [ ] **Step 1: Update triggers**
+
+Remove `paths-ignore` so frontend, compose, and backend changes all run tests.
+
+- [ ] **Step 2: Replace env decryption**
+
+Set explicit CI environment variables for backend tests:
+
+```yaml
+ENVIRONMENT: test
+DB_DRIVER: postgres
+DB_USER: root
+DB_PASSWORD: secret
+DB_SOURCE: postgresql://root:secret@localhost:5432/nostalgia?sslmode=disable
+DB_URL: postgresql://root:secret@localhost:5432/nostalgia?sslmode=disable
+MIGRATION_URL: file://db/migration
+RESOURCE_PATH: ./resources
+DOMAIN: http://localhost:8080
+HTTP_SERVER_ADDRESS: 0.0.0.0:8080
+GRPC_GATEWAY_ADDRESS: 0.0.0.0:9091
+GRPC_SERVER_ADDRESS: 0.0.0.0:9090
+TOKEN_SYMMETRIC_KEY: 12345678901234567890123456789012
+SETUP_TOKEN: ci-setup-token
+ACCESS_TOKEN_DURATION: 15m
+REFRESH_TOKEN_DURATION: 24h
+REDIS_ADDRESS: localhost:6379
+EMAIL_SENDER_NAME: Nostalgia CI
+EMAIL_SENDER_ADDRESS: noreply@example.com
+EMAIL_SENDER_PASSWORD: ci-mail-password
+UPLOAD_FILE_SIZE_LIMIT: 5242880
+UPLOAD_FILE_ALLOWED_MIME: image/jpeg,image/png
+HTTP_PROXY_ADDR: ""
+```
+
+- [ ] **Step 3: Add frontend job**
+
+Use Bun setup, install frontend dependencies, then run:
+
+```bash
+cd web/frontend
+bun install --frozen-lockfile
+bun test
+bun run type-check
+bun run build
+```
+
+- [ ] **Step 4: Add compose config job**
+
+Create a temporary `.env` from `.env.example` without real secrets and run:
+
+```bash
+docker compose config --quiet
+docker compose -f docker-compose.dev.yaml config --quiet
+```
+
+### Task 3: Verify Phase 1
+
+**Files:**
+- Modified files above.
+
+- [ ] **Step 1: Run targeted guard test**
+
+Run:
+
+```bash
+cd web/frontend && bun test src/deploy/nginxConfig.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run backend test suite**
+
+Run:
+
+```bash
+make test
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run frontend checks**
+
+Run:
+
+```bash
+cd web/frontend && bun test
+cd web/frontend && bun run type-check
+cd web/frontend && bun run build
+```
+
+Expected: PASS; the existing Vite chunk-size warning may remain until Phase 2.
+
+- [ ] **Step 4: Run compose checks**
+
+Run:
+
+```bash
+docker compose config --quiet
+docker compose -f docker-compose.dev.yaml config --quiet
+```
+
+Expected: PASS; local missing-variable warnings are acceptable if `.env` is absent.
+
+- [ ] **Step 5: Commit phase 1**
+
+Commit:
+
+```bash
+git add .github/workflows/test.yml web/frontend/src/deploy/nginxConfig.test.ts docs/superpowers/plans/2026-06-11-platform-hardening-roadmap.md
+git commit -m "ci: cover frontend and compose checks"
+```

--- a/web/frontend/src/deploy/nginxConfig.test.ts
+++ b/web/frontend/src/deploy/nginxConfig.test.ts
@@ -76,4 +76,17 @@ describe('nginx deployment ingress config', () => {
       expect(readme).not.toContain(key)
     }
   })
+
+  test('test workflow covers backend frontend and compose checks without env decryption', () => {
+    const workflow = readRepoFile('.github/workflows/test.yml')
+
+    expect(workflow).not.toContain('paths-ignore:')
+    expect(workflow).not.toContain('make decrypt_env env=dev')
+    expect(workflow).toContain('make test')
+    expect(workflow).toContain('bun test')
+    expect(workflow).toContain('bun run type-check')
+    expect(workflow).toContain('bun run build')
+    expect(workflow).toContain('docker compose config --quiet')
+    expect(workflow).toContain('docker compose -f docker-compose.dev.yaml config --quiet')
+  })
 })


### PR DESCRIPTION
## Summary
- Add a six-phase platform hardening roadmap covering CI, bundle splitting, XSS/CSP, health checks, database legacy audit, and deployment polish.
- Expand the test workflow to run backend tests, frontend Bun checks, and Docker Compose config validation.
- Remove test workflow dependency on decrypting `.env.dev.enc`; backend CI now uses explicit test environment variables.

## Test Plan
- `make test`
- `cd web/frontend && bun test`
- `cd web/frontend && bun run type-check`
- `cd web/frontend && bun run build`
- `docker compose config --quiet && docker compose -f docker-compose.dev.yaml config --quiet`
