### PR TITLE
perf: split frontend editor bundles

### DIFF
--- a/docs/superpowers/plans/2026-06-11-platform-hardening-roadmap.md
+++ b/docs/superpowers/plans/2026-06-11-platform-hardening-roadmap.md
@@ -197,3 +197,31 @@ Commit:
 git add .github/workflows/test.yml web/frontend/src/deploy/nginxConfig.test.ts docs/superpowers/plans/2026-06-11-platform-hardening-roadmap.md
 git commit -m "ci: cover frontend and compose checks"
 ```
+
+## Phase 2 File Structure
+
+- Modify `web/frontend/vite.config.ts`: add Rollup `manualChunks` rules for CKEditor, content rendering, and admin editor modules.
+- Modify `web/frontend/src/router/index.ts`: lazy-load article detail routes so Prism/content rendering code is not pulled into the app shell route table.
+- Add `web/frontend/src/deploy/viteBuildConfig.test.ts`: guard the bundle-splitting contract.
+
+## Phase 2 Tasks
+
+### Task 1: Add Bundle Splitting Guard Tests
+
+- [x] Add a Vite config guard that requires manual chunks for CKEditor, Prism/content rendering, and admin editor code.
+- [x] Add a router guard that prevents article detail from being statically imported into the public route table.
+- [x] Verify the new guard fails before implementation with `cd web/frontend && bun test src/deploy/viteBuildConfig.test.ts`.
+
+### Task 2: Split Frontend Bundles
+
+- [x] Add `manualChunks` rules that isolate CKEditor dependencies in `ckeditor`.
+- [x] Add `manualChunks` rules that isolate Prism, DOMPurify, and sanitization in `content-rendering`.
+- [x] Add `manualChunks` rules that isolate admin article editor shell code in `admin-editor`.
+- [x] Lazy-load `ArticleView.vue` from the router so article highlighting code loads on demand.
+
+### Task 3: Verify Phase 2
+
+- [x] Run `cd web/frontend && bun test`.
+- [x] Run `cd web/frontend && bun run type-check`.
+- [x] Run `cd web/frontend && bun run build`.
+- [x] Confirm build output includes separate `ArticleView`, `content-rendering`, `admin-editor`, and `ckeditor` chunks.

--- a/web/frontend/src/deploy/viteBuildConfig.test.ts
+++ b/web/frontend/src/deploy/viteBuildConfig.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const repoRoot = resolve(import.meta.dir, '../../../..')
+const readRepoFile = (path: string) => readFileSync(resolve(repoRoot, path), 'utf8')
+
+describe('vite bundle splitting config', () => {
+  test('keeps editor and code highlighting dependencies out of the public entry chunk', () => {
+    const config = readRepoFile('web/frontend/vite.config.ts')
+
+    expect(config).toContain('manualChunks')
+    expect(config).toContain('ckeditor')
+    expect(config).toContain('prism')
+    expect(config).toContain('content-rendering')
+    expect(config).toContain('admin-editor')
+  })
+
+  test('lazy-loads article detail so Prism is not part of the app shell route table', () => {
+    const router = readRepoFile('web/frontend/src/router/index.ts')
+
+    expect(router).not.toContain("import ArticleView from '@/views/article/ArticleView.vue'")
+    expect(router).toContain("component: () => import('@/views/article/ArticleView.vue')")
+  })
+})

--- a/web/frontend/src/router/index.ts
+++ b/web/frontend/src/router/index.ts
@@ -1,7 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import HomeView from '../views/HomeView.vue'
 import LoginUser from '@/components/LoginUser.vue'
-import ArticleView from '@/views/article/ArticleView.vue'
 import RegisterUser from '@/components/RegisterUser.vue'
 import VerifyEmail from '@/views/auth/VerifyEmail.vue'
 import NotFound from '@/views/NotFound.vue'
@@ -53,7 +52,7 @@ const router = createRouter({
     {
       path: '/article/:id?',
       name: 'articleView',
-      component: ArticleView,
+      component: () => import('@/views/article/ArticleView.vue'),
       props: true
     },
     {

--- a/web/frontend/vite.config.ts
+++ b/web/frontend/vite.config.ts
@@ -4,6 +4,34 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vueJsx from '@vitejs/plugin-vue-jsx'
 
+const normalizeModuleId = (id: string) => id.replaceAll('\\', '/')
+
+const manualChunks = (id: string) => {
+  const normalizedId = normalizeModuleId(id)
+
+  if (
+    normalizedId.includes('/node_modules/ckeditor5/') ||
+    normalizedId.includes('/node_modules/@ckeditor/ckeditor5-vue/')
+  ) {
+    return 'ckeditor'
+  }
+
+  if (
+    normalizedId.includes('/node_modules/prismjs/') ||
+    normalizedId.includes('/node_modules/dompurify/') ||
+    normalizedId.includes('/src/util/sanitizeHtml.ts')
+  ) {
+    return 'content-rendering'
+  }
+
+  if (
+    normalizedId.includes('/src/views/admin/AdminArticleEditorView.vue') ||
+    normalizedId.includes('/src/admin/editor/')
+  ) {
+    return 'admin-editor'
+  }
+}
+
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
@@ -25,6 +53,13 @@ export default defineConfig({
         changeOrigin: true,
       },
       '/resources': 'http://localhost:8080'
+    }
+  },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks
+      }
     }
   }
 })


### PR DESCRIPTION
## Summary
- add Vite manual chunk rules for CKEditor, content rendering, and admin editor code
- lazy-load the article detail route so Prism/content rendering stays out of the app shell
- document Phase 2 bundle splitting progress in the platform hardening roadmap

## Verification
- cd web/frontend && bun test
- cd web/frontend && bun run type-check
- cd web/frontend && bun run build

Note: the build still reports Vite's large chunk warning for the lazy-loaded CKEditor vendor chunk, but the public index chunk is reduced and editor dependencies are isolated.