### PR TITLE
fix: harden frontend rich text and csp

### DIFF
--- a/docs/superpowers/plans/2026-06-11-platform-hardening-roadmap.md
+++ b/docs/superpowers/plans/2026-06-11-platform-hardening-roadmap.md
@@ -225,3 +225,40 @@ git commit -m "ci: cover frontend and compose checks"
 - [x] Run `cd web/frontend && bun run type-check`.
 - [x] Run `cd web/frontend && bun run build`.
 - [x] Confirm build output includes separate `ArticleView`, `content-rendering`, `admin-editor`, and `ckeditor` chunks.
+
+## Phase 3 File Structure
+
+- Add `web/frontend/src/util/sanitizeHtmlPolicy.ts`: central rich-text sanitization policy for URL protocols, target link rel values, and profile-aware DOMPurify config.
+- Modify `web/frontend/src/util/sanitizeHtml.ts`: apply the centralized sanitization policy from the DOMPurify hook.
+- Add `web/frontend/src/util/sanitizeHtmlPolicy.test.ts`: guard dangerous HTML/URL policy behavior.
+- Add `web/frontend/src/deploy/frontendSourceHygiene.test.ts`: prevent stray production `console.log`/`console.debug`/`console.info` calls.
+- Add `web/security-headers.conf`: shared Nginx security header and CSP include.
+- Modify `web/nginx.conf`, `web/Dockerfile`, and `web/Dockerfile.dev`: include and ship the CSP/security header file.
+
+## Phase 3 Tasks
+
+### Task 1: Add XSS, CSP, and Console Guard Tests
+
+- [x] Add sanitizer policy tests for allowed URL protocols and same-origin references.
+- [x] Add sanitizer policy tests rejecting `javascript:`, obfuscated `javascript:`, `data:`, `vbscript:`, and `ftp:` URLs.
+- [x] Add sanitizer policy tests for `rel="noopener noreferrer"` normalization and article/comment profiles.
+- [x] Add Nginx deployment tests requiring a shipped baseline CSP include.
+- [x] Add frontend source hygiene tests blocking stray production `console.log`/`console.debug`/`console.info` calls.
+- [x] Verify the new tests fail before implementation.
+
+### Task 2: Harden Frontend Rich Text and Nginx Headers
+
+- [x] Centralize DOMPurify config and URL/rel policy, preserving CKEditor article styles while making comment rendering stricter.
+- [x] Apply the policy from the existing DOMPurify `afterSanitizeAttributes` hook.
+- [x] Add an Nginx Content-Security-Policy baseline compatible with app scripts, CKEditor styles, uploaded/self-hosted assets, and HTTPS images/media.
+- [x] Include security headers in cacheable/static response locations so Nginx header inheritance cannot drop them.
+- [x] Copy the security header include into production and development web images.
+- [x] Remove stray production `console.log` calls.
+
+### Task 3: Verify Phase 3
+
+- [x] Run `cd web/frontend && bun test`.
+- [x] Run `cd web/frontend && bun run type-check`.
+- [x] Run `cd web/frontend && bun run build`.
+- [x] Run Nginx syntax validation with mounted `web/nginx.conf`, `web/security-headers.conf`, and temporary local certificates.
+- [x] Run `docker compose config --quiet && docker compose -f docker-compose.dev.yaml config --quiet`.

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -27,6 +27,7 @@ COPY --from=build-frontend /app/frontend/dist /usr/share/nginx/html/
 
 # 拷贝 nginx 配置
 COPY nginx.conf /etc/nginx/nginx.conf
+COPY security-headers.conf /etc/nginx/security-headers.conf
 
 # 日志文件夹
 RUN mkdir -p /etc/nginx/logs && touch /etc/nginx/logs/error.log && \

--- a/web/Dockerfile.dev
+++ b/web/Dockerfile.dev
@@ -35,6 +35,7 @@ COPY --from=build-frontend /app/frontend/dist /usr/share/nginx/html/
 
 # 拷贝 nginx 配置
 COPY nginx.conf /etc/nginx/nginx.conf
+COPY security-headers.conf /etc/nginx/security-headers.conf
 
 # 日志文件夹
 RUN mkdir -p /etc/nginx/logs && touch /etc/nginx/logs/error.log && \

--- a/web/frontend/src/components/article/CommentItem.vue
+++ b/web/frontend/src/components/article/CommentItem.vue
@@ -25,7 +25,7 @@ const displayedChildren = computed(() => {
   if (!props.comment.child) return []
   return showAllChildren.value ? props.comment.child : props.comment.child.slice(0, 2)
 })
-const sanitizedContent = computed(() => sanitizeHtml(props.comment.content || ''))
+const sanitizedContent = computed(() => sanitizeHtml(props.comment.content || '', { profile: 'comment' }))
 
 const deleteComment = inject<(id: number) => void>('deleteComment')
 

--- a/web/frontend/src/deploy/frontendSourceHygiene.test.ts
+++ b/web/frontend/src/deploy/frontendSourceHygiene.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative, resolve } from 'node:path'
+
+const frontendSrcRoot = resolve(import.meta.dir, '..')
+const ignoredDirectories = new Set(['node_modules', 'dist'])
+
+const sourceFiles = (directory: string): string[] =>
+  readdirSync(directory).flatMap((entry) => {
+    const path = join(directory, entry)
+    const stats = statSync(path)
+
+    if (stats.isDirectory()) {
+      if (ignoredDirectories.has(entry)) return []
+      return sourceFiles(path)
+    }
+
+    return /\.(ts|vue)$/.test(entry) ? [path] : []
+  })
+
+describe('frontend source hygiene', () => {
+  test('does not ship stray console logging in production source', () => {
+    const offenders = sourceFiles(frontendSrcRoot)
+      .map((path) => ({
+        path: relative(frontendSrcRoot, path),
+        source: readFileSync(path, 'utf8')
+      }))
+      .filter(({ path }) => !path.endsWith('.test.ts'))
+      .flatMap(({ path, source }) =>
+        [...source.matchAll(/\bconsole\.(log|debug|info)\s*\(/g)].map((match) => `${path}:${match[1]}`)
+      )
+
+    expect(offenders).toEqual([])
+  })
+})

--- a/web/frontend/src/deploy/nginxConfig.test.ts
+++ b/web/frontend/src/deploy/nginxConfig.test.ts
@@ -21,6 +21,23 @@ describe('nginx deployment ingress config', () => {
     expect(nginx).toContain('/etc/nginx/certs/cloudflare-origin.key')
   })
 
+  test('ships a baseline content security policy with cacheable responses', () => {
+    const nginx = readRepoFile('web/nginx.conf')
+    const securityHeaders = readRepoFile('web/security-headers.conf')
+    const webDockerfile = readRepoFile('web/Dockerfile')
+    const webDevDockerfile = readRepoFile('web/Dockerfile.dev')
+
+    expect(securityHeaders).toContain('Content-Security-Policy')
+    expect(securityHeaders).toContain("default-src 'self'")
+    expect(securityHeaders).toContain("script-src 'self'")
+    expect(securityHeaders).toContain("object-src 'none'")
+    expect(securityHeaders).toContain("frame-ancestors 'self'")
+    expect(nginx).toContain('include /etc/nginx/security-headers.conf;')
+    expect(nginx.match(/include \/etc\/nginx\/security-headers\.conf;/g)?.length).toBeGreaterThanOrEqual(4)
+    expect(webDockerfile).toContain('COPY security-headers.conf /etc/nginx/security-headers.conf')
+    expect(webDevDockerfile).toContain('COPY security-headers.conf /etc/nginx/security-headers.conf')
+  })
+
   test('production compose exposes web as the only public ingress', () => {
     const compose = readRepoFile('docker-compose.yaml')
 

--- a/web/frontend/src/util/request.ts
+++ b/web/frontend/src/util/request.ts
@@ -77,7 +77,6 @@ async function refreshToken() {
     const controller = new AbortController()
     const timeoutId = setTimeout(() => controller.abort(), 5000) // 5秒超时
 
-    console.log('刷新token')
     const response = await axios.post('/tokens/renew_access', {
       refresh_token: storageService.get(storageService.USER_REFRESH_TOKEN)
     }, { signal: controller.signal })
@@ -90,7 +89,6 @@ async function refreshToken() {
     // 通知所有等待请求 token 刷新完毕
     subscribers.forEach((callback) => callback());
     subscribers = [];
-    console.log('刷新成功')
   } catch (error) {
     console.error('刷新 token 失败，登出' + error)
     logout()

--- a/web/frontend/src/util/sanitizeHtml.ts
+++ b/web/frontend/src/util/sanitizeHtml.ts
@@ -1,21 +1,28 @@
 import DOMPurify from 'dompurify'
 
-const allowedUri = /^(?:(?:https?|mailto|tel):|\/|#)/i
+import {
+  getSafeTargetRel,
+  getSanitizedHtmlConfig,
+  isAllowedSanitizedUri,
+  type SanitizedHtmlProfile
+} from './sanitizeHtmlPolicy'
+
+export interface SanitizeHtmlOptions {
+  profile?: SanitizedHtmlProfile
+}
 
 DOMPurify.addHook('afterSanitizeAttributes', (node) => {
   if (!(node instanceof HTMLElement)) return
 
   if (node.hasAttribute('target')) {
-    node.setAttribute('rel', 'noopener noreferrer')
+    node.setAttribute('rel', getSafeTargetRel(node.getAttribute('rel') || ''))
   }
 
   for (const attr of ['href', 'src']) {
     const value = node.getAttribute(attr)
-    if (value && !allowedUri.test(value)) node.removeAttribute(attr)
+    if (value && !isAllowedSanitizedUri(value)) node.removeAttribute(attr)
   }
 })
 
-export const sanitizeHtml = (html: string) =>
-  DOMPurify.sanitize(html, {
-    ADD_ATTR: ['target']
-  })
+export const sanitizeHtml = (html: string, options: SanitizeHtmlOptions = {}) =>
+  DOMPurify.sanitize(html, getSanitizedHtmlConfig(options.profile))

--- a/web/frontend/src/util/sanitizeHtmlPolicy.test.ts
+++ b/web/frontend/src/util/sanitizeHtmlPolicy.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  getSafeTargetRel,
+  getSanitizedHtmlConfig,
+  isAllowedSanitizedUri,
+  SANITIZED_HTML_CONFIG
+} from './sanitizeHtmlPolicy'
+
+describe('sanitizeHtmlPolicy', () => {
+  test('allows only public article-safe URL protocols and same-origin references', () => {
+    expect(isAllowedSanitizedUri('https://example.com/post')).toBe(true)
+    expect(isAllowedSanitizedUri('http://example.com/post')).toBe(true)
+    expect(isAllowedSanitizedUri('mailto:author@example.com')).toBe(true)
+    expect(isAllowedSanitizedUri('tel:+15551234567')).toBe(true)
+    expect(isAllowedSanitizedUri('/resources/content/image.png')).toBe(true)
+    expect(isAllowedSanitizedUri('#comments')).toBe(true)
+  })
+
+  test('rejects scriptable or embedded-data URL protocols', () => {
+    expect(isAllowedSanitizedUri('javascript:alert(1)')).toBe(false)
+    expect(isAllowedSanitizedUri(' java\nscript:alert(1)')).toBe(false)
+    expect(isAllowedSanitizedUri('data:text/html,<script>alert(1)</script>')).toBe(false)
+    expect(isAllowedSanitizedUri('vbscript:msgbox(1)')).toBe(false)
+    expect(isAllowedSanitizedUri('ftp://example.com/file')).toBe(false)
+  })
+
+  test('normalizes target links to prevent opener access', () => {
+    expect(getSafeTargetRel()).toBe('noopener noreferrer')
+    expect(getSafeTargetRel('nofollow')).toBe('nofollow noopener noreferrer')
+    expect(getSafeTargetRel('noopener')).toBe('noopener noreferrer')
+  })
+
+  test('keeps the base DOMPurify config focused on CKEditor output', () => {
+    expect(SANITIZED_HTML_CONFIG.ADD_ATTR).toContain('target')
+    expect(SANITIZED_HTML_CONFIG.FORBID_TAGS).toEqual(['script', 'style', 'iframe', 'object', 'embed'])
+  })
+
+  test('keeps article output visually aligned while making comments stricter', () => {
+    expect(getSanitizedHtmlConfig('article').FORBID_ATTR ?? []).not.toContain('style')
+    expect(getSanitizedHtmlConfig('comment').FORBID_ATTR).toContain('style')
+  })
+})

--- a/web/frontend/src/util/sanitizeHtmlPolicy.ts
+++ b/web/frontend/src/util/sanitizeHtmlPolicy.ts
@@ -1,0 +1,48 @@
+import type { Config } from 'dompurify'
+
+export type SanitizedHtmlProfile = 'article' | 'comment'
+
+export const SANITIZED_HTML_CONFIG: Config = {
+  ADD_ATTR: ['target'],
+  FORBID_TAGS: ['script', 'style', 'iframe', 'object', 'embed']
+}
+
+const COMMENT_SANITIZED_HTML_CONFIG: Config = {
+  ...SANITIZED_HTML_CONFIG,
+  FORBID_ATTR: ['style']
+}
+
+const cloneConfig = (config: Config): Config => ({
+  ...config,
+  ADD_ATTR: Array.isArray(config.ADD_ATTR) ? [...config.ADD_ATTR] : config.ADD_ATTR,
+  FORBID_TAGS: config.FORBID_TAGS ? [...config.FORBID_TAGS] : undefined,
+  FORBID_ATTR: config.FORBID_ATTR ? [...config.FORBID_ATTR] : undefined
+})
+
+export const getSanitizedHtmlConfig = (profile: SanitizedHtmlProfile = 'article') =>
+  cloneConfig(profile === 'comment' ? COMMENT_SANITIZED_HTML_CONFIG : SANITIZED_HTML_CONFIG)
+
+const allowedProtocols = new Set(['http:', 'https:', 'mailto:', 'tel:'])
+
+const normalizeUriForProtocolCheck = (uri: string) =>
+  uri.trim().replace(/[\u0000-\u001F\u007F\s]+/g, '')
+
+export const isAllowedSanitizedUri = (uri: string) => {
+  const normalizedUri = normalizeUriForProtocolCheck(uri)
+
+  if (normalizedUri.startsWith('/') || normalizedUri.startsWith('#')) return true
+
+  const protocolMatch = normalizedUri.match(/^([a-z][a-z0-9+.-]*:)/i)
+  if (!protocolMatch) return false
+
+  return allowedProtocols.has(protocolMatch[1].toLowerCase())
+}
+
+export const getSafeTargetRel = (rel = '') => {
+  const values = new Set(rel.split(/\s+/).filter(Boolean))
+
+  values.add('noopener')
+  values.add('noreferrer')
+
+  return [...values].join(' ')
+}

--- a/web/frontend/src/views/article/EditorView.vue
+++ b/web/frontend/src/views/article/EditorView.vue
@@ -101,23 +101,17 @@ const toast = useToast();
 
 // 当编辑器准备好时的回调
 const onEditorReady = (editorInstance: ClassicEditor) => {
-  console.log("editorInstance", editorInstance)
   editor.value = editorInstance
   if (id !== '') {
     articleStore.getArticle(id as string).then((res: any) => {
       post.value = res.data
       editorData.value = post.value.content
       isPublish.value = post.value.is_publish
-      console.log(res)
     })
   }
 }
 
 const editorComponent = ref(null)
-
-/*editor.value.plugins.get('FileRepository').on('uploadComplete', (event, data) => {
-  console.log('Image upload completed:', data);
-});*/
 
 const save = () => {
   if (id != "") {

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -49,11 +49,10 @@ http {
         ssl_protocols TLSv1.2 TLSv1.3;
         ssl_prefer_server_ciphers off;
 
-        add_header X-Frame-Options "SAMEORIGIN" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header X-XSS-Protection "1; mode=block" always;
+        include /etc/nginx/security-headers.conf;
 
         location = /api {
+            include /etc/nginx/security-headers.conf;
             proxy_pass http://api:8080;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
@@ -64,6 +63,7 @@ http {
         }
 
         location /api/ {
+            include /etc/nginx/security-headers.conf;
             proxy_pass http://api:8080;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
@@ -74,6 +74,7 @@ http {
         }
 
         location = /v1 {
+            include /etc/nginx/security-headers.conf;
             proxy_pass http://api:9091;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
@@ -84,6 +85,7 @@ http {
         }
 
         location /v1/ {
+            include /etc/nginx/security-headers.conf;
             proxy_pass http://api:9091;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
@@ -99,6 +101,7 @@ http {
             index index.html;
             try_files $uri $uri/ /index.html;
             # HTML文件不缓存，确保每次发版立刻生效
+            include /etc/nginx/security-headers.conf;
             add_header Cache-Control "no-store, no-cache, must-revalidate";
         }
 
@@ -107,6 +110,7 @@ http {
             root /usr/share/nginx/html;
             expires 1y;
             # 带有hash的资源直接强缓存
+            include /etc/nginx/security-headers.conf;
             add_header Cache-Control "public, immutable";
         }
 
@@ -116,8 +120,8 @@ http {
             autoindex off;
 
             expires 7d;
+            include /etc/nginx/security-headers.conf;
             add_header Cache-Control "public, no-transform";
-            add_header X-Content-Type-Options nosniff;
 
             # 禁止访问隐藏文件
             location ~ /\. {

--- a/web/security-headers.conf
+++ b/web/security-headers.conf
@@ -1,0 +1,4 @@
+add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; media-src 'self' https:; form-action 'self'; upgrade-insecure-requests" always;
+add_header X-Frame-Options "SAMEORIGIN" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;


### PR DESCRIPTION
## Summary
- centralize rich-text sanitization policy with article/comment profiles and dangerous URL protocol guards
- add Nginx CSP/security header include and ship it in web Docker images
- add frontend source hygiene checks and remove stray production console logs
- record Phase 3 progress in the platform hardening roadmap

## Verification
- cd web/frontend && bun test
- cd web/frontend && bun run type-check
- cd web/frontend && bun run build
- docker run --rm --add-host api:127.0.0.1 ... nginx:alpine nginx -t
- docker compose config --quiet && docker compose -f docker-compose.dev.yaml config --quiet

Note: Vite still reports the known lazy-loaded CKEditor chunk-size warning from Phase 2.