### PR TITLE
feat: add deployment healthchecks

### DIFF
--- a/api/health.go
+++ b/api/health.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	healthStatusOK        = "ok"
+	readinessStatusReady  = "ready"
+	readinessStatusFailed = "not_ready"
+	readinessCheckOK      = "ok"
+	readinessCheckFailed  = "unavailable"
+	readinessTimeout      = 2 * time.Second
+)
+
+func (server *Server) healthz(ctx *gin.Context) {
+	ctx.JSON(http.StatusOK, gin.H{"status": healthStatusOK})
+}
+
+func (server *Server) readyz(ctx *gin.Context) {
+	checkCtx, cancel := context.WithTimeout(ctx.Request.Context(), readinessTimeout)
+	defer cancel()
+
+	checks := gin.H{
+		"database": readinessCheckOK,
+		"redis":    readinessCheckOK,
+	}
+	statusCode := http.StatusOK
+	status := readinessStatusReady
+
+	if server.store == nil || server.store.Ping(checkCtx) != nil {
+		checks["database"] = readinessCheckFailed
+		statusCode = http.StatusServiceUnavailable
+		status = readinessStatusFailed
+	}
+
+	if server.cache == nil || server.cache.Ping(checkCtx) != nil {
+		checks["redis"] = readinessCheckFailed
+		statusCode = http.StatusServiceUnavailable
+		status = readinessStatusFailed
+	}
+
+	ctx.JSON(statusCode, gin.H{
+		"status": status,
+		"checks": checks,
+	})
+}

--- a/api/health_test.go
+++ b/api/health_test.go
@@ -1,0 +1,115 @@
+package api
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mockdb "github.com/MonitorAllen/nostalgia/db/mock"
+	mockcache "github.com/MonitorAllen/nostalgia/internal/cache/mock"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthzAPI(t *testing.T) {
+	server := newTestServer(t, nil, nil, nil)
+	recorder := httptest.NewRecorder()
+
+	request, err := http.NewRequest(http.MethodGet, "/healthz", nil)
+	require.NoError(t, err)
+
+	server.router.ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	requireHealthBody(t, recorder.Body.Bytes(), "ok")
+}
+
+func TestReadyzAPI(t *testing.T) {
+	testCases := []struct {
+		name          string
+		buildStubs    func(store *mockdb.MockStore, redisCache *mockcache.MockCache)
+		checkResponse func(t *testing.T, recorder *httptest.ResponseRecorder)
+	}{
+		{
+			name: "Ready",
+			buildStubs: func(store *mockdb.MockStore, redisCache *mockcache.MockCache) {
+				store.EXPECT().Ping(gomock.Any()).Times(1).Return(nil)
+				redisCache.EXPECT().Ping(gomock.Any()).Times(1).Return(nil)
+			},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusOK, recorder.Code)
+				requireReadyBody(t, recorder.Body.Bytes(), "ready", "ok", "ok")
+			},
+		},
+		{
+			name: "DatabaseUnavailable",
+			buildStubs: func(store *mockdb.MockStore, redisCache *mockcache.MockCache) {
+				store.EXPECT().Ping(gomock.Any()).Times(1).Return(sql.ErrConnDone)
+				redisCache.EXPECT().Ping(gomock.Any()).Times(1).Return(nil)
+			},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+				requireReadyBody(t, recorder.Body.Bytes(), "not_ready", "unavailable", "ok")
+			},
+		},
+		{
+			name: "RedisUnavailable",
+			buildStubs: func(store *mockdb.MockStore, redisCache *mockcache.MockCache) {
+				store.EXPECT().Ping(gomock.Any()).Times(1).Return(nil)
+				redisCache.EXPECT().Ping(gomock.Any()).Times(1).Return(errors.New("redis unavailable"))
+			},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+				requireReadyBody(t, recorder.Body.Bytes(), "not_ready", "ok", "unavailable")
+			},
+		},
+	}
+
+	for i := range testCases {
+		tc := testCases[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			storeCtrl := gomock.NewController(t)
+			defer storeCtrl.Finish()
+			cacheCtrl := gomock.NewController(t)
+			defer cacheCtrl.Finish()
+
+			store := mockdb.NewMockStore(storeCtrl)
+			redisCache := mockcache.NewMockCache(cacheCtrl)
+			tc.buildStubs(store, redisCache)
+
+			server := newTestServer(t, store, nil, redisCache)
+			recorder := httptest.NewRecorder()
+
+			request, err := http.NewRequest(http.MethodGet, "/readyz", nil)
+			require.NoError(t, err)
+
+			server.router.ServeHTTP(recorder, request)
+			tc.checkResponse(t, recorder)
+		})
+	}
+}
+
+func requireHealthBody(t *testing.T, body []byte, status string) {
+	var payload struct {
+		Status string `json:"status"`
+	}
+	err := json.Unmarshal(body, &payload)
+	require.NoError(t, err)
+	require.Equal(t, status, payload.Status)
+}
+
+func requireReadyBody(t *testing.T, body []byte, status string, database string, redis string) {
+	var payload struct {
+		Status string            `json:"status"`
+		Checks map[string]string `json:"checks"`
+	}
+	err := json.Unmarshal(body, &payload)
+	require.NoError(t, err)
+	require.Equal(t, status, payload.Status)
+	require.Equal(t, database, payload.Checks["database"])
+	require.Equal(t, redis, payload.Checks["redis"])
+}

--- a/api/server.go
+++ b/api/server.go
@@ -69,6 +69,9 @@ func (server *Server) setupRouter() {
 	router.Static("/temp/upload", "./temp/upload")
 	router.Static("/resources/", "./resources")
 
+	router.GET("/healthz", server.healthz)
+	router.GET("/readyz", server.readyz)
+
 	public := router.Group("/api")
 	{
 		public.GET("/setup/status", server.setupStatus)

--- a/db/mock/store.go
+++ b/db/mock/store.go
@@ -628,6 +628,20 @@ func (mr *MockStoreMockRecorder) ListCommentsByArticleID(arg0, arg1 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCommentsByArticleID", reflect.TypeOf((*MockStore)(nil).ListCommentsByArticleID), arg0, arg1)
 }
 
+// Ping mocks base method.
+func (m *MockStore) Ping(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Ping", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Ping indicates an expected call of Ping.
+func (mr *MockStoreMockRecorder) Ping(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ping", reflect.TypeOf((*MockStore)(nil).Ping), arg0)
+}
+
 // SearchArticles mocks base method.
 func (m *MockStore) SearchArticles(arg0 context.Context, arg1 db.SearchArticlesParams) ([]db.SearchArticlesRow, error) {
 	m.ctrl.T.Helper()

--- a/db/sqlc/store.go
+++ b/db/sqlc/store.go
@@ -9,6 +9,7 @@ import (
 // Store provides all functions to execute db queries and transactions
 type Store interface {
 	Querier
+	Ping(ctx context.Context) error
 	CreateUserTx(ctx context.Context, arg CreateUserTxParams) (CreateUserTxResult, error)
 	VerifyEmailTx(ctx context.Context, arg VerifyEmailTxParams) (VerifyEmailTxResult, error)
 	UpdateArticleTx(ctx context.Context, arg UpdateArticleTxParams) (UpdateArticleTxResult, error)
@@ -29,4 +30,8 @@ func NewStore(connPool *pgxpool.Pool) Store {
 		connPool: connPool,
 		Queries:  New(connPool),
 	}
+}
+
+func (store *SQLStore) Ping(ctx context.Context) error {
+	return store.connPool.Ping(ctx)
 }

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -12,12 +12,23 @@ services:
       - nostalgia
     volumes:
       - ./postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U \"$${POSTGRES_USER}\" -d \"$${POSTGRES_DB}\""]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
     restart: unless-stopped
 
   redis:
     image: redis:7-alpine
     networks:
       - nostalgia
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     restart: unless-stopped
 
   api:
@@ -34,10 +45,18 @@ services:
       - DB_SOURCE=postgresql://${DB_USER}:${DB_PASSWORD}@postgres:5432/nostalgia?sslmode=disable
       - REDIS_ADDRESS=redis:6379
     depends_on:
-      - postgres
-      - redis
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     entrypoint: ["/app/wait-for.sh", "postgres:5432", "--", "/app/start.sh"]
     command: ["/app/main"]
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/healthz >/dev/null"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
     restart: unless-stopped
 
   web:
@@ -53,7 +72,14 @@ services:
     networks:
       - nostalgia
     depends_on:
-      - api
+      api:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost/healthz >/dev/null"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
     restart: unless-stopped
 
 volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,12 +10,23 @@ services:
       - nostalgia
     volumes:
       - ./postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U \"$${POSTGRES_USER}\" -d \"$${POSTGRES_DB}\""]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
     restart: unless-stopped
 
   redis:
     image: redis:7-alpine
     networks:
       - nostalgia
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     restart: unless-stopped
 
   api:
@@ -30,10 +41,18 @@ services:
       - DB_SOURCE=postgresql://${DB_USER}:${DB_PASSWORD}@postgres:5432/nostalgia?sslmode=disable
       - REDIS_ADDRESS=redis:6379
     depends_on:
-      - postgres
-      - redis
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     entrypoint: ["/app/wait-for.sh", "postgres:5432", "--", "/app/start.sh"]
     command: ["/app/main"]
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/healthz >/dev/null"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
     restart: unless-stopped
 
   web:
@@ -48,7 +67,14 @@ services:
     networks:
       - nostalgia
     depends_on:
-      - api
+      api:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost/healthz >/dev/null"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
     restart: unless-stopped
 
 volumes:

--- a/docs/deployment-healthchecks.md
+++ b/docs/deployment-healthchecks.md
@@ -1,0 +1,17 @@
+# Deployment Health Checks
+
+Nostalgia exposes two operational probes from the API service:
+
+- `GET /healthz`: process liveness. It returns `200` with `{"status":"ok"}` when the Gin API process can serve HTTP.
+- `GET /readyz`: dependency readiness. It returns `200` with `{"status":"ready"}` only when PostgreSQL and Redis both respond to `Ping`; otherwise it returns `503` with failing checks marked as `unavailable`.
+
+Nginx proxies HTTPS `/healthz` and `/readyz` to the API service. The HTTP server keeps a local `/healthz` response for the web container healthcheck while all other HTTP traffic is redirected to HTTPS.
+
+Docker Compose healthchecks:
+
+- `postgres`: `pg_isready` against the configured database.
+- `redis`: `redis-cli ping`.
+- `api`: `GET http://localhost:8080/healthz`.
+- `web`: `GET http://localhost/healthz`.
+
+The API service waits for healthy PostgreSQL and Redis services. The web service waits for a healthy API service.

--- a/docs/superpowers/plans/2026-06-11-platform-hardening-roadmap.md
+++ b/docs/superpowers/plans/2026-06-11-platform-hardening-roadmap.md
@@ -262,3 +262,46 @@ git commit -m "ci: cover frontend and compose checks"
 - [x] Run `cd web/frontend && bun run build`.
 - [x] Run Nginx syntax validation with mounted `web/nginx.conf`, `web/security-headers.conf`, and temporary local certificates.
 - [x] Run `docker compose config --quiet && docker compose -f docker-compose.dev.yaml config --quiet`.
+
+## Phase 4 File Structure
+
+- Add `api/health.go`: Gin liveness and readiness endpoints.
+- Add `api/health_test.go`: API behavior tests for `/healthz` and `/readyz`.
+- Modify `db/sqlc/store.go`: expose `Ping(ctx)` on `Store` for database readiness.
+- Modify `internal/cache/cache.go` and `internal/cache/redis.go`: expose Redis `Ping(ctx)` through the cache interface.
+- Regenerate `db/mock/store.go` and `internal/cache/mock/redis.go`.
+- Modify `web/nginx.conf`: route HTTPS health endpoints to API and keep local HTTP `/healthz` for web container checks.
+- Modify `docker-compose.yaml` and `docker-compose.dev.yaml`: add healthchecks and healthy dependency conditions.
+- Add `docs/deployment-healthchecks.md`: document operational signals.
+
+## Phase 4 Tasks
+
+### Task 1: Add Healthcheck Guard Tests
+
+- [x] Add API tests for `/healthz`.
+- [x] Add API tests for `/readyz` success, database failure, and Redis failure.
+- [x] Add deployment tests for Nginx `/healthz` and `/readyz` routing.
+- [x] Add deployment tests for Compose healthchecks on `postgres`, `redis`, `api`, and `web`.
+- [x] Verify the new tests fail before implementation.
+
+### Task 2: Implement Health and Readiness Signals
+
+- [x] Add database `Ping(ctx)` to the store abstraction.
+- [x] Add Redis `Ping(ctx)` to the cache abstraction.
+- [x] Implement `GET /healthz` without external dependency checks.
+- [x] Implement `GET /readyz` with PostgreSQL and Redis checks.
+- [x] Regenerate Go mocks after interface changes.
+- [x] Add Nginx health endpoint routing.
+- [x] Add Docker Compose healthchecks and `condition: service_healthy` dependencies.
+- [x] Document expected operational signals.
+
+### Task 3: Verify Phase 4
+
+- [x] Run targeted API health tests.
+- [x] Run targeted Nginx/Compose guard tests.
+- [x] Run `make test`.
+- [x] Run `cd web/frontend && bun test`.
+- [x] Run `cd web/frontend && bun run type-check`.
+- [x] Run `cd web/frontend && bun run build`.
+- [x] Run Nginx syntax validation with mounted config and temporary local certificates.
+- [x] Run `docker compose config --quiet && docker compose -f docker-compose.dev.yaml config --quiet`.

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -6,6 +6,7 @@ import (
 )
 
 type Cache interface {
+	Ping(ctx context.Context) error
 	Get(ctx context.Context, key string, dest any) (bool, error)
 	Set(ctx context.Context, key string, value any, ttl time.Duration) error
 	Del(ctx context.Context, key string) error

--- a/internal/cache/mock/redis.go
+++ b/internal/cache/mock/redis.go
@@ -93,6 +93,20 @@ func (mr *MockCacheMockRecorder) IsExpired(arg0, arg1 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsExpired", reflect.TypeOf((*MockCache)(nil).IsExpired), arg0, arg1)
 }
 
+// Ping mocks base method.
+func (m *MockCache) Ping(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Ping", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Ping indicates an expected call of Ping.
+func (mr *MockCacheMockRecorder) Ping(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ping", reflect.TypeOf((*MockCache)(nil).Ping), arg0)
+}
+
 // Set mocks base method.
 func (m *MockCache) Set(arg0 context.Context, arg1 string, arg2 interface{}, arg3 time.Duration) error {
 	m.ctrl.T.Helper()

--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -22,6 +22,10 @@ func NewRedisCache(config util.Config) *RedisCache {
 	}
 }
 
+func (r *RedisCache) Ping(ctx context.Context) error {
+	return r.rdb.Ping(ctx).Err()
+}
+
 func (r *RedisCache) Get(ctx context.Context, key string, dest any) (bool, error) {
 	val, err := r.rdb.Get(ctx, key).Result()
 	if errors.Is(err, redis.Nil) {

--- a/web/frontend/src/deploy/nginxConfig.test.ts
+++ b/web/frontend/src/deploy/nginxConfig.test.ts
@@ -38,6 +38,17 @@ describe('nginx deployment ingress config', () => {
     expect(webDevDockerfile).toContain('COPY security-headers.conf /etc/nginx/security-headers.conf')
   })
 
+  test('routes operational health endpoints through nginx', () => {
+    const nginx = readRepoFile('web/nginx.conf')
+
+    expect(nginx).toContain('location = /healthz')
+    expect(nginx).toContain('location = /readyz')
+    expect(nginx).toContain('proxy_pass http://api:8080/healthz')
+    expect(nginx).toContain('proxy_pass http://api:8080/readyz')
+    expect(nginx).toMatch(/listen 80 default_server;[\s\S]*location = \/healthz[\s\S]*return 200 "ok\\n";/)
+    expect(nginx).toMatch(/listen 80 default_server;[\s\S]*location \/ \{[\s\S]*return 301 https:\/\/\$host\$request_uri;/)
+  })
+
   test('production compose exposes web as the only public ingress', () => {
     const compose = readRepoFile('docker-compose.yaml')
 
@@ -64,6 +75,19 @@ describe('nginx deployment ingress config', () => {
 
     expect(productionCompose).toMatch(/api:\n[\s\S]*env_file:\n[\s\S]*path: \.env/)
     expect(developmentCompose).toMatch(/api:\n[\s\S]*env_file:\n[\s\S]*path: \.env/)
+  })
+
+  test('compose declares healthchecks for all runtime services', () => {
+    const productionCompose = readRepoFile('docker-compose.yaml')
+    const developmentCompose = readRepoFile('docker-compose.dev.yaml')
+
+    for (const compose of [productionCompose, developmentCompose]) {
+      expect(compose).toMatch(/postgres:\n[\s\S]*healthcheck:\n[\s\S]*pg_isready/)
+      expect(compose).toMatch(/redis:\n[\s\S]*healthcheck:\n[\s\S]*redis-cli ping/)
+      expect(compose).toMatch(/api:\n[\s\S]*healthcheck:\n[\s\S]*\/healthz/)
+      expect(compose).toMatch(/web:\n[\s\S]*healthcheck:\n[\s\S]*\/healthz/)
+      expect(compose).toContain('condition: service_healthy')
+    }
   })
 
   test('api and web images declare their runtime-only responsibilities', () => {

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -37,7 +37,15 @@ http {
         listen 80 default_server;
         server_name _;
 
-        return 301 https://$host$request_uri;
+        location = /healthz {
+            access_log off;
+            add_header Content-Type text/plain;
+            return 200 "ok\n";
+        }
+
+        location / {
+            return 301 https://$host$request_uri;
+        }
     }
 
     server {
@@ -50,6 +58,28 @@ http {
         ssl_prefer_server_ciphers off;
 
         include /etc/nginx/security-headers.conf;
+
+        location = /healthz {
+            include /etc/nginx/security-headers.conf;
+            proxy_pass http://api:8080/healthz;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $client_real_ip;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location = /readyz {
+            include /etc/nginx/security-headers.conf;
+            proxy_pass http://api:8080/readyz;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $client_real_ip;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
 
         location = /api {
             include /etc/nginx/security-headers.conf;


### PR DESCRIPTION
## Summary
- add API /healthz and /readyz probes with PostgreSQL and Redis readiness checks
- add Docker Compose healthchecks and healthy dependency conditions for postgres, redis, api, and web
- route operational health endpoints through Nginx and document expected signals
- record Phase 4 progress in the platform hardening roadmap

## Verification
- make test
- cd web/frontend && bun test
- cd web/frontend && bun run type-check
- cd web/frontend && bun run build
- docker run --rm --add-host api:127.0.0.1 ... nginx:alpine nginx -t
- docker compose config --quiet && docker compose -f docker-compose.dev.yaml config --quiet

Note: local compose config emits missing environment variable warnings when .env is absent, but exits 0. Vite still reports the known lazy-loaded CKEditor chunk-size warning.