### PR TITLE
chore: audit legacy database structures

### DIFF
--- a/doc/db.dbml
+++ b/doc/db.dbml
@@ -1,16 +1,26 @@
-Table "admins" {
-  "id" int8 [pk, not null, increment, note: '主键ID']
-  "username" varchar [unique, not null, note: '管理员名称']
-  "hashed_password" varchar [not null, note: '密码']
-  "is_active" bool [not null, default: false, note: '是否激活，默认：否']
-  "role_id" int8 [not null, default: 2, note: '角色ID，默认：2']
+Table "users" {
+  "id" uuid [pk, not null, note: '主键ID']
+  "username" varchar [unique, not null, note: '用户名']
+  "hashed_password" varchar [not null]
+  "full_name" varchar [not null, note: '全名']
+  "email" varchar [unique, not null, note: '邮箱']
+  "is_email_verified" bool [not null, default: false, note: '邮箱是否验证']
+  "about" varchar [not null, default: '', note: '介绍']
+  "role" varchar [not null, default: 'visitor', note: 'admin 或 visitor']
   "created_at" timestamptz [not null, default: `now()`, note: '创建时间']
   "updated_at" timestamptz [not null, default: '0001-01-01 00:00:00+00', note: '更新时间']
-  Note: '管理员账号表'
+  "deleted_at" timestamptz [not null, default: '0001-01-01 00:00:00+00', note: '删除时间']
+
+  Indexes {
+    role [type: btree, name: "users_role_idx"]
+    role [unique, type: btree, name: "users_single_admin_idx", note: "Partial index where role = 'admin'"]
+  }
+
+  Note: '用户表'
 }
 
 Table "articles" {
-  "id" uuid [pk, not null]
+  "id" uuid [pk, not null, note: '主键ID']
   "title" varchar [not null, note: '标题']
   "summary" varchar [not null, default: '', note: '摘要']
   "content" text [not null, note: '内容']
@@ -18,17 +28,23 @@ Table "articles" {
   "likes" int4 [not null, default: 0, note: '点赞数']
   "is_publish" bool [not null, default: false, note: '是否发布']
   "owner" uuid [not null, note: '拥有者']
-  "created_at" timestamptz [not null, default: `now()`]
-  "updated_at" timestamptz [not null, default: '0001-01-01 00:00:00+00']
-  "deleted_at" timestamptz [not null, default: '0001-01-01 00:00:00+00']
-  "category_id" int8 [not null, default: 1]
-  "cover" varchar [not null, default: '']
-  "last_updated" timestamptz [default: `now()`]
+  "created_at" timestamptz [not null, default: `now()`, note: '创建时间']
+  "updated_at" timestamptz [not null, default: '0001-01-01 00:00:00+00', note: '更新时间']
+  "deleted_at" timestamptz [not null, default: '0001-01-01 00:00:00+00', note: '删除时间']
+  "category_id" int8 [not null, default: 1, note: '分类ID']
+  "slug" varchar(100) [unique, note: '短标识']
+  "cover" varchar [not null, default: '', note: '封面']
+  "last_updated" timestamptz [not null, default: `now()`, note: '最后更新时间']
+  "check_outdated" bool [not null, default: true, note: '检查过时']
+  "read_time" varchar(20) [not null, default: '', note: '阅读时间']
 
   Indexes {
-    (category_id, is_publish, created_at) [type: btree, name: "articles_category_id_is_publish_created_at_idx"]
     (is_publish, created_at) [type: btree, name: "articles_is_publish_created_at_idx"]
+    (category_id, is_publish, created_at) [type: btree, name: "articles_category_id_is_publish_created_at_idx"]
+    slug [unique, type: btree, name: "articles_slug_idx"]
   }
+
+  Note: '文章表'
 }
 
 Table "categories" {
@@ -37,113 +53,61 @@ Table "categories" {
   "is_system" bool [not null, default: false, note: '是否为系统分类']
   "created_at" timestamptz [not null, default: `now()`]
   "updated_at" timestamptz [not null, default: `now()`]
+
   Note: '文章分类表'
 }
 
 Table "comments" {
-  "id" int8 [pk, not null, increment]
+  "id" int8 [pk, not null, increment, note: '主键ID']
   "content" varchar [not null, note: '评论内容']
   "article_id" uuid [not null, note: '文章ID']
   "parent_id" int8 [not null, default: 0, note: '父评论ID']
-  "likes" int4 [not null, default: 0]
+  "likes" int4 [not null, default: 0, note: '点赞数']
   "from_user_id" uuid [not null, note: '评论人ID']
   "to_user_id" uuid [not null, note: '被评论人ID']
-  "created_at" timestamptz [not null, default: `now()`]
-  "deleted_at" timestamptz [not null, default: '0001-01-01 00:00:00+00']
-}
-
-Table "role_permissions" {
-  "id" int8 [pk, not null, increment, note: '主键ID']
-  "role_id" int8 [not null, note: '角色ID']
-  "menu_id" int8 [not null, note: '菜单ID']
-  "created_by" int8 [not null, note: '创建人ID']
   "created_at" timestamptz [not null, default: `now()`, note: '创建时间']
+  "deleted_at" timestamptz [not null, default: '0001-01-01 00:00:00+00', note: '删除时间']
 
-  Indexes {
-    (role_id, menu_id) [type: btree, name: "role_permissions_role_id_menu_id_idx"]
-  }
-  Note: '角色权限表'
-}
-
-Table "roles" {
-  "id" int8 [pk, not null, increment, note: '主键ID']
-  "role_name" varchar [unique, not null, note: '角色名称']
-  "description" text [not null, default: '', note: '角色描述']
-  "is_system" bool [not null, default: false, note: '是否为系统角色']
-  "created_at" timestamptz [not null, default: `now()`, note: '创建时间']
-  Note: '角色表'
-}
-
-Table "schema_migrations" {
-  "version" int8 [pk, not null]
-  "dirty" bool [not null]
-}
-
-Table "sessions" {
-  "id" uuid [pk, not null]
-  "user_id" uuid [not null]
-  "refresh_token" varchar [not null]
-  "user_agent" varchar [not null]
-  "client_ip" varchar [not null]
-  "is_blocked" bool [not null, default: false]
-  "expires_at" timestamptz [not null]
-  "created_at" timestamptz [not null, default: `now()`]
-}
-
-Table "sys_menus" {
-  "id" int8 [pk, not null, increment, note: '主键ID']
-  "name" varchar [not null, note: '菜单名称']
-  "path" varchar [not null, default: '', note: '菜单路径']
-  "icon" varchar [not null, default: '', note: '菜单图标']
-  "is_active" bool [not null, default: false, note: '是否激活，默认：否']
-  "type" int4 [not null, default: 2, note: '1：目录；2：菜单；3：按钮（事件）']
-  "sort" int4 [not null, default: 0, note: '排序编号']
-  "parent_id" int8 [note: '父菜单ID']
-  "created_at" timestamptz [not null, default: `now()`, note: '创建时间']
-  "updated_at" timestamptz [not null, default: '0001-01-01 00:00:00+00']
-
-  Indexes {
-    (name, parent_id) [type: btree, name: "sys_menus_name_parent_id_idx"]
-  }
-  Note: '后台系统菜单表'
+  Note: '文章评论表'
 }
 
 Table "tags" {
-  "id" int8 [pk, not null, increment]
+  "id" int8 [pk, not null, increment, note: '主键ID']
   "name" varchar [not null, note: '名称']
   "article_id" uuid [not null, note: '文章ID']
-  "created_at" timestamptz [not null, default: `now()`]
+  "created_at" timestamptz [not null, default: `now()`, note: '创建时间']
+
+  Note: '标签表'
 }
 
-Table "users" {
-  "id" uuid [pk, not null]
-  "username" varchar [unique, not null]
-  "hashed_password" varchar [not null]
-  "full_name" varchar [not null]
-  "email" varchar [unique, not null]
-  "is_email_verified" bool [not null, default: false]
-  "about" varchar [not null, default: '', note: '介绍']
-  "role" varchar [not null, default: 'visitor']
-  "created_at" timestamptz [not null, default: `now()`]
-  "updated_at" timestamptz [not null, default: '0001-01-01 00:00:00+00']
-  "deleted_at" timestamptz [not null, default: '0001-01-01 00:00:00+00']
+Table "sessions" {
+  "id" uuid [pk, not null, note: '主键ID']
+  "user_id" uuid [not null, note: '用户ID']
+  "refresh_token" varchar [not null, note: '刷新token']
+  "user_agent" varchar [not null, note: '用户浏览器']
+  "client_ip" varchar [not null, note: '用户IP']
+  "is_blocked" bool [not null, default: false, note: '是否阻止登陆']
+  "expires_at" timestamptz [not null, note: '到期时间']
+  "created_at" timestamptz [not null, default: `now()`, note: '创建时间']
+
+  Note: '用户会话表'
 }
 
 Table "verify_emails" {
-  "id" int8 [pk, not null, increment]
-  "user_id" uuid [not null]
-  "email" varchar [not null]
-  "secret_code" varchar [not null]
-  "is_used" bool [not null, default: false]
-  "created_at" timestamptz [not null, default: `now()`]
-  "expired_at" timestamptz [not null, default: `(now() + '00:15:00'::interval)`]
+  "id" int8 [pk, not null, increment, note: '主键ID']
+  "user_id" uuid [not null, note: '用户ID']
+  "email" varchar [not null, note: '用户邮箱']
+  "secret_code" varchar [not null, note: '验证密钥']
+  "is_used" bool [not null, default: false, note: '是否使用']
+  "created_at" timestamptz [not null, default: `now()`, note: '创建时间']
+  "expired_at" timestamptz [not null, default: `(now() + '00:15:00'::interval)`, note: '到期时间']
+
+  Note: '邮箱验证表'
 }
 
-Ref "admins_role_id_fkey":"roles"."id" < "admins"."role_id"
+Ref "articles_owner_fkey":"users"."id" < "articles"."owner"
 
 Ref "articles_category_id_fkey":"categories"."id" < "articles"."category_id"
-
-Ref "articles_owner_fkey":"users"."id" < "articles"."owner"
 
 Ref "comments_article_id_fkey":"articles"."id" < "comments"."article_id"
 
@@ -151,16 +115,8 @@ Ref "comments_from_user_id_fkey":"users"."id" < "comments"."from_user_id"
 
 Ref "comments_to_user_id_fkey":"users"."id" < "comments"."to_user_id"
 
-Ref "role_permissions_created_by_fkey":"admins"."id" < "role_permissions"."created_by"
-
-Ref "role_permissions_menu_id_fkey":"sys_menus"."id" < "role_permissions"."menu_id"
-
-Ref "role_permissions_role_id_fkey":"roles"."id" < "role_permissions"."role_id"
+Ref "tags_article_id_fkey":"articles"."id" < "tags"."article_id"
 
 Ref "sessions_user_id_fkey":"users"."id" < "sessions"."user_id"
-
-Ref "sys_menus_parent_id_fkey":"sys_menus"."id" < "sys_menus"."parent_id"
-
-Ref "tags_article_id_fkey":"articles"."id" < "tags"."article_id"
 
 Ref "verify_emails_user_id_fkey":"users"."id" < "verify_emails"."user_id"

--- a/doc/schema.sql
+++ b/doc/schema.sql
@@ -1,6 +1,6 @@
--- SQL dump generated using DBML (dbml.dbdiagram.io)
--- Database: PostgreSQL
--- Generated at: 2025-09-08T09:02:41.246Z
+-- Current PostgreSQL schema after migrations 000001 through 000009.
+
+CREATE EXTENSION IF NOT EXISTS pgroonga;
 
 CREATE TABLE "users" (
   "id" uuid PRIMARY KEY,
@@ -13,7 +13,16 @@ CREATE TABLE "users" (
   "role" varchar NOT NULL DEFAULT 'visitor',
   "created_at" timestamptz NOT NULL DEFAULT (now()),
   "updated_at" timestamptz NOT NULL DEFAULT '0001-01-01 00:00:00Z',
-  "deleted_at" timestamptz NOT NULL DEFAULT '0001-01-01 00:00:00Z'
+  "deleted_at" timestamptz NOT NULL DEFAULT '0001-01-01 00:00:00Z',
+  CONSTRAINT users_role_check CHECK (role IN ('admin', 'visitor'))
+);
+
+CREATE TABLE "categories" (
+  "id" bigserial PRIMARY KEY,
+  "name" varchar UNIQUE NOT NULL DEFAULT '',
+  "is_system" bool NOT NULL DEFAULT false,
+  "created_at" timestamptz NOT NULL DEFAULT (now()),
+  "updated_at" timestamptz NOT NULL DEFAULT (now())
 );
 
 CREATE TABLE "articles" (
@@ -25,29 +34,15 @@ CREATE TABLE "articles" (
   "likes" int NOT NULL DEFAULT 0,
   "is_publish" boolean NOT NULL DEFAULT false,
   "owner" uuid NOT NULL,
-  "category_id" bigint NOT NULL,
   "created_at" timestamptz NOT NULL DEFAULT (now()),
   "updated_at" timestamptz NOT NULL DEFAULT '0001-01-01 00:00:00Z',
-  "deleted_at" timestamptz NOT NULL DEFAULT '0001-01-01 00:00:00Z'
-);
-
-CREATE TABLE "categories" (
-  "id" bigserial PRIMARY KEY,
-  "name" varchar UNIQUE NOT NULL DEFAULT '',
-  "is_system" bool NOT NULL DEFAULT false,
-  "created_at" timestamptz NOT NULL DEFAULT (now()),
-  "updated_at" timestamptz NOT NULL DEFAULT (now())
-);
-
-CREATE TABLE "comments" (
-  "id" bigserial PRIMARY KEY,
-  "content" varchar NOT NULL,
-  "article_id" uuid NOT NULL,
-  "parent_id" int NOT NULL DEFAULT 0,
-  "from_user_id" uuid NOT NULL,
-  "to_user_id" uuid NOT NULL,
-  "created_at" timestamptz NOT NULL DEFAULT (now()),
-  "deleted_at" timestamptz NOT NULL DEFAULT '0001-01-01 00:00:00Z'
+  "deleted_at" timestamptz NOT NULL DEFAULT '0001-01-01 00:00:00Z',
+  "category_id" bigint NOT NULL DEFAULT 1,
+  "slug" varchar(100),
+  "cover" varchar NOT NULL DEFAULT '',
+  "last_updated" timestamptz NOT NULL DEFAULT now(),
+  "check_outdated" bool NOT NULL DEFAULT true,
+  "read_time" varchar(20) NOT NULL DEFAULT ''
 );
 
 CREATE TABLE "tags" (
@@ -59,7 +54,7 @@ CREATE TABLE "tags" (
 
 CREATE TABLE "sessions" (
   "id" uuid PRIMARY KEY,
-  "username" varchar NOT NULL,
+  "user_id" uuid NOT NULL,
   "refresh_token" varchar NOT NULL,
   "user_agent" varchar NOT NULL,
   "client_ip" varchar NOT NULL,
@@ -70,7 +65,7 @@ CREATE TABLE "sessions" (
 
 CREATE TABLE "verify_emails" (
   "id" bigserial PRIMARY KEY,
-  "user_id" varchar NOT NULL,
+  "user_id" uuid NOT NULL,
   "email" varchar NOT NULL,
   "secret_code" varchar NOT NULL,
   "is_used" bool NOT NULL DEFAULT false,
@@ -78,53 +73,30 @@ CREATE TABLE "verify_emails" (
   "expired_at" timestamptz NOT NULL DEFAULT (now() + interval '15 minutes')
 );
 
-CREATE TABLE "roles" (
+CREATE TABLE "comments" (
   "id" bigserial PRIMARY KEY,
-  "role_name" varchar UNIQUE NOT NULL,
-  "description" varchar NOT NULL DEFAULT '',
-  "is_system" bool NOT NULL DEFAULT false,
+  "content" varchar NOT NULL,
+  "article_id" uuid NOT NULL,
+  "parent_id" bigint NOT NULL DEFAULT 0,
+  "likes" int NOT NULL DEFAULT 0,
+  "from_user_id" uuid NOT NULL,
+  "to_user_id" uuid NOT NULL,
   "created_at" timestamptz NOT NULL DEFAULT (now()),
-  "updated_at" timestamptz NOT NULL DEFAULT '0001-01-01 00:00:00Z'
-);
-
-CREATE TABLE "admins" (
-  "id" bigserial PRIMARY KEY,
-  "username" varchar UNIQUE NOT NULL,
-  "hashed_password" varchar NOT NULL,
-  "is_active" bool NOT NULL DEFAULT false,
-  "role_id" bigint NOT NULL DEFAULT 2,
-  "created_at" timestamptz NOT NULL DEFAULT (now()),
-  "updated_at" timestamptz NOT NULL DEFAULT '0001-01-01 00:00:00Z'
-);
-
-CREATE TABLE "sys_menus" (
-  "id" bigserial PRIMARY KEY,
-  "name" varchar NOT NULL,
-  "path" varchar NOT NULL DEFAULT '',
-  "icon" varchar NOT NULL DEFAULT '',
-  "is_active" bool NOT NULL DEFAULT false,
-  "type" int NOT NULL DEFAULT 2,
-  "sort" int NOT NULL DEFAULT 0,
-  "parent_id" bigint DEFAULT null,
-  "created_at" timestamptz NOT NULL DEFAULT (now()),
-  "updated_at" timestamptz NOT NULL DEFAULT '0001-01-01 00:00:00Z'
-);
-
-CREATE TABLE "role_permissions" (
-  "id" bigserial PRIMARY KEY,
-  "role_id" bigint NOT NULL,
-  "menu_id" bigint NOT NULL,
-  "created_by" bigint NOT NULL,
-  "created_at" timestamptz NOT NULL DEFAULT (now())
+  "deleted_at" timestamptz NOT NULL DEFAULT '0001-01-01 00:00:00Z'
 );
 
 CREATE INDEX ON "articles" ("is_publish", "created_at");
 
 CREATE INDEX ON "articles" ("category_id", "is_publish", "created_at");
 
-CREATE UNIQUE INDEX ON "sys_menus" ("name", "parent_id");
+CREATE UNIQUE INDEX ON "articles" ("slug");
 
-CREATE UNIQUE INDEX ON "role_permissions" ("role_id", "menu_id");
+CREATE INDEX articles_search_pgroonga_idx ON articles
+  USING pgroonga ((title || ' ' || summary || ' ' || content));
+
+CREATE INDEX IF NOT EXISTS users_role_idx ON users(role);
+
+CREATE UNIQUE INDEX IF NOT EXISTS users_single_admin_idx ON users(role) WHERE role = 'admin';
 
 COMMENT ON TABLE "users" IS '用户表';
 
@@ -139,6 +111,8 @@ COMMENT ON COLUMN "users"."email" IS '邮箱';
 COMMENT ON COLUMN "users"."is_email_verified" IS '邮箱是否验证';
 
 COMMENT ON COLUMN "users"."about" IS '介绍';
+
+COMMENT ON COLUMN "users"."role" IS 'admin 或 visitor';
 
 COMMENT ON COLUMN "users"."created_at" IS '创建时间';
 
@@ -166,6 +140,16 @@ COMMENT ON COLUMN "articles"."owner" IS '拥有者';
 
 COMMENT ON COLUMN "articles"."category_id" IS '分类ID';
 
+COMMENT ON COLUMN "articles"."slug" IS '短标识';
+
+COMMENT ON COLUMN "articles"."cover" IS '封面';
+
+COMMENT ON COLUMN "articles"."last_updated" IS '最后更新时间';
+
+COMMENT ON COLUMN "articles"."check_outdated" IS '检查过时';
+
+COMMENT ON COLUMN "articles"."read_time" IS '阅读时间';
+
 COMMENT ON COLUMN "articles"."updated_at" IS '更新时间';
 
 COMMENT ON COLUMN "articles"."deleted_at" IS '删除时间';
@@ -186,6 +170,8 @@ COMMENT ON COLUMN "comments"."article_id" IS '文章ID';
 
 COMMENT ON COLUMN "comments"."parent_id" IS '父评论ID';
 
+COMMENT ON COLUMN "comments"."likes" IS '点赞数';
+
 COMMENT ON COLUMN "comments"."from_user_id" IS '评论人ID';
 
 COMMENT ON COLUMN "comments"."to_user_id" IS '被评论人ID';
@@ -204,7 +190,7 @@ COMMENT ON TABLE "sessions" IS '用户会话表';
 
 COMMENT ON COLUMN "sessions"."id" IS '主键ID';
 
-COMMENT ON COLUMN "sessions"."username" IS '用户名';
+COMMENT ON COLUMN "sessions"."user_id" IS '用户ID';
 
 COMMENT ON COLUMN "sessions"."refresh_token" IS '刷新token';
 
@@ -234,86 +220,18 @@ COMMENT ON COLUMN "verify_emails"."created_at" IS '创建时间';
 
 COMMENT ON COLUMN "verify_emails"."expired_at" IS '到期时间';
 
-COMMENT ON TABLE "roles" IS '角色表';
-
-COMMENT ON COLUMN "roles"."id" IS '主键ID';
-
-COMMENT ON COLUMN "roles"."role_name" IS '角色名称';
-
-COMMENT ON COLUMN "roles"."description" IS '角色描述';
-
-COMMENT ON COLUMN "roles"."is_system" IS '是否为系统角色';
-
-COMMENT ON COLUMN "roles"."created_at" IS '创建时间';
-
-COMMENT ON COLUMN "roles"."updated_at" IS '更新时间';
-
-COMMENT ON TABLE "admins" IS '管理员账号表';
-
-COMMENT ON COLUMN "admins"."id" IS '主键ID';
-
-COMMENT ON COLUMN "admins"."username" IS '管理员名称';
-
-COMMENT ON COLUMN "admins"."hashed_password" IS '密码';
-
-COMMENT ON COLUMN "admins"."is_active" IS '是否激活，默认：否';
-
-COMMENT ON COLUMN "admins"."role_id" IS '角色ID，默认：2';
-
-COMMENT ON COLUMN "admins"."created_at" IS '创建时间';
-
-COMMENT ON COLUMN "admins"."updated_at" IS '更新时间';
-
-COMMENT ON TABLE "sys_menus" IS '后台系统菜单表';
-
-COMMENT ON COLUMN "sys_menus"."id" IS '主键ID';
-
-COMMENT ON COLUMN "sys_menus"."name" IS '菜单名称';
-
-COMMENT ON COLUMN "sys_menus"."path" IS '菜单路径';
-
-COMMENT ON COLUMN "sys_menus"."icon" IS '菜单图标';
-
-COMMENT ON COLUMN "sys_menus"."is_active" IS '是否激活，默认：否';
-
-COMMENT ON COLUMN "sys_menus"."type" IS '1：目录；2：菜单；3：按钮（事件）';
-
-COMMENT ON COLUMN "sys_menus"."sort" IS '排序编号';
-
-COMMENT ON COLUMN "sys_menus"."parent_id" IS '父菜单ID';
-
-COMMENT ON COLUMN "sys_menus"."created_at" IS '创建时间';
-
-COMMENT ON TABLE "role_permissions" IS '角色权限表';
-
-COMMENT ON COLUMN "role_permissions"."id" IS '主键ID';
-
-COMMENT ON COLUMN "role_permissions"."role_id" IS '角色ID';
-
-COMMENT ON COLUMN "role_permissions"."menu_id" IS '菜单ID';
-
-COMMENT ON COLUMN "role_permissions"."created_by" IS '创建人ID';
-
-COMMENT ON COLUMN "role_permissions"."created_at" IS '创建时间';
-
 ALTER TABLE "articles" ADD FOREIGN KEY ("owner") REFERENCES "users" ("id");
 
 ALTER TABLE "articles" ADD FOREIGN KEY ("category_id") REFERENCES "categories" ("id");
 
-ALTER TABLE "comments" ADD FOREIGN KEY ("article_id") REFERENCES "articles" ("id") ON DELETE CASCADE;
+ALTER TABLE "tags" ADD FOREIGN KEY ("article_id") REFERENCES "articles" ("id");
 
-ALTER TABLE "tags" ADD FOREIGN KEY ("article_id") REFERENCES "articles" ("id") ON DELETE CASCADE;
-
-ALTER TABLE "sessions" ADD FOREIGN KEY ("username") REFERENCES "users" ("id");
+ALTER TABLE "sessions" ADD FOREIGN KEY ("user_id") REFERENCES "users" ("id");
 
 ALTER TABLE "verify_emails" ADD FOREIGN KEY ("user_id") REFERENCES "users" ("id");
 
-ALTER TABLE "admins" ADD FOREIGN KEY ("role_id") REFERENCES "roles" ("id");
+ALTER TABLE "comments" ADD FOREIGN KEY ("article_id") REFERENCES "articles" ("id");
 
-ALTER TABLE "sys_menus" ADD FOREIGN KEY ("parent_id") REFERENCES "sys_menus" ("id");
+ALTER TABLE "comments" ADD FOREIGN KEY ("from_user_id") REFERENCES "users" ("id");
 
-ALTER TABLE "role_permissions" ADD FOREIGN KEY ("role_id") REFERENCES "roles" ("id");
-
-ALTER TABLE "role_permissions" ADD FOREIGN KEY ("menu_id") REFERENCES "sys_menus" ("id");
-
-ALTER TABLE "role_permissions" ADD FOREIGN KEY ("created_by") REFERENCES "admins" ("id");
+ALTER TABLE "comments" ADD FOREIGN KEY ("to_user_id") REFERENCES "users" ("id");

--- a/docs/superpowers/plans/2026-06-11-platform-hardening-roadmap.md
+++ b/docs/superpowers/plans/2026-06-11-platform-hardening-roadmap.md
@@ -305,3 +305,39 @@ git commit -m "ci: cover frontend and compose checks"
 - [x] Run `cd web/frontend && bun run build`.
 - [x] Run Nginx syntax validation with mounted config and temporary local certificates.
 - [x] Run `docker compose config --quiet && docker compose -f docker-compose.dev.yaml config --quiet`.
+
+## Phase 5 File Structure
+
+- Add `web/frontend/src/deploy/databaseLegacyAudit.test.ts`: guard current schema docs, frontend admin types, and sqlc runtime models against removed admin/RBAC tables.
+- Modify `doc/db.dbml` and `doc/schema.sql`: update current database documentation after `000009_remove_legacy_admin_rbac`.
+- Modify `web/frontend/src/admin/types.ts`: remove legacy `role_id` from admin user types and model the unified `role` string.
+
+## Phase 5 Tasks
+
+### Task 1: Audit Legacy Admin/RBAC References
+
+- [x] Scan migrations, sqlc output, db queries, frontend admin code, and docs for `admins`, `roles`, `role_permissions`, `sys_menus`, `role_id`, and related legacy RBAC assumptions.
+- [x] Confirm runtime sqlc models and queries no longer expose legacy admin/RBAC tables.
+- [x] Confirm historical migrations still mention old tables because they are part of the migration chain and should not be rewritten.
+- [x] Identify stale current docs in `doc/db.dbml` and `doc/schema.sql`.
+- [x] Identify stale frontend admin API type `role_id`.
+
+### Task 2: Add Legacy Structure Guard Tests
+
+- [x] Add tests proving current schema docs do not expose removed admin/RBAC tables.
+- [x] Add tests proving frontend admin API types no longer model `role_id`.
+- [x] Add tests proving sqlc runtime models do not include legacy admin/RBAC structs.
+- [x] Verify the new tests fail before implementation.
+
+### Task 3: Clean Current Schema Docs and Types
+
+- [x] Update `doc/db.dbml` to current post-migration tables.
+- [x] Update `doc/schema.sql` to current post-migration SQL structure.
+- [x] Remove `role_id` from frontend admin types and use unified `role?: string`.
+
+### Task 4: Verify Phase 5
+
+- [x] Run targeted legacy audit tests.
+- [x] Run `cd web/frontend && bun test`.
+- [x] Run `cd web/frontend && bun run type-check`.
+- [x] Run `make test`.

--- a/web/frontend/src/admin/types.ts
+++ b/web/frontend/src/admin/types.ts
@@ -3,8 +3,7 @@ export type AdminInt64 = string | number
 export interface AdminUser {
   id: AdminInt64
   username: string
-  is_active?: boolean
-  role_id?: AdminInt64
+  role?: string
   created_at?: string
 }
 

--- a/web/frontend/src/deploy/databaseLegacyAudit.test.ts
+++ b/web/frontend/src/deploy/databaseLegacyAudit.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const repoRoot = resolve(import.meta.dir, '../../../..')
+const readRepoFile = (path: string) => readFileSync(resolve(repoRoot, path), 'utf8')
+
+const legacyTables = ['admins', 'roles', 'role_permissions', 'sys_menus']
+
+describe('database legacy structure audit', () => {
+  test('current database documentation does not expose removed admin rbac tables', () => {
+    const schema = readRepoFile('doc/schema.sql')
+    const dbml = readRepoFile('doc/db.dbml')
+
+    for (const table of legacyTables) {
+      expect(schema).not.toContain(`CREATE TABLE "${table}"`)
+      expect(dbml).not.toContain(`Table "${table}"`)
+    }
+  })
+
+  test('frontend admin API types no longer model legacy role ids', () => {
+    const adminTypes = readRepoFile('web/frontend/src/admin/types.ts')
+
+    expect(adminTypes).not.toContain('role_id')
+    expect(adminTypes).toContain('role?: string')
+  })
+
+  test('runtime sqlc models do not include legacy admin rbac tables', () => {
+    const models = readRepoFile('db/sqlc/models.go')
+
+    expect(models).not.toContain('type Admin struct')
+    expect(models).not.toContain('type Role struct')
+    expect(models).not.toContain('type RolePermission struct')
+    expect(models).not.toContain('type SysMenu struct')
+  })
+})


### PR DESCRIPTION
## Summary
- Update current database schema docs after removing legacy admin/RBAC runtime tables.
- Remove legacy `role_id` from frontend admin user typing and use unified `role`.
- Add Bun guard tests for current schema docs, frontend admin types, and sqlc runtime models.

## Test Plan
- [x] `cd web/frontend && bun test`
- [x] `cd web/frontend && bun run type-check`
- [x] `make test`
- [x] `cd web/frontend && bun test src/deploy/databaseLegacyAudit.test.ts`
- [x] `git diff --check`
