### PR TITLE
chore: ignore codegraph index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ certs/
 /resources/
 
 .agent
+.codegraph/
 .agents/
 !.agents/
 .agents/*


### PR DESCRIPTION
## Summary
- Ignore the local `.codegraph/` index directory generated by CodeGraph.

## Verification
- `git diff --check origin/master...HEAD`
- `git check-ignore -v .codegraph`