### PR TITLE
fix: P1 认证与数据完整性（禁用用户拦截、验证邮件链接、软删除过滤）

### DIFF
--- a/api/main_test.go
+++ b/api/main_test.go
@@ -1,21 +1,42 @@
 package api
 
 import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
 	db "github.com/MonitorAllen/nostalgia/db/sqlc"
 	"github.com/MonitorAllen/nostalgia/internal/cache"
 	"github.com/MonitorAllen/nostalgia/util"
 	"github.com/MonitorAllen/nostalgia/worker"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
-	"os"
-	"testing"
-	"time"
 )
+
+// noopCache is a cache that stores nothing — Get always reports "not found".
+// Used as a default for tests that don't exercise cache behaviour.
+type noopCache struct{}
+
+func (noopCache) Ping(context.Context) error                            { return nil }
+func (noopCache) Get(context.Context, string, any) (bool, error)        { return false, nil }
+func (noopCache) Set(context.Context, string, any, time.Duration) error { return nil }
+func (noopCache) Del(context.Context, string) error                     { return nil }
+func (noopCache) SetNX(context.Context, string, any, time.Duration) (bool, error) {
+	return true, nil
+}
+func (noopCache) Incr(context.Context, string) (int64, error)     { return 0, nil }
+func (noopCache) IsExpired(context.Context, string) (bool, error) { return false, nil }
+func (noopCache) Close() error                                    { return nil }
 
 func newTestServer(t *testing.T, store db.Store, taskDistributor worker.TaskDistributor, cache cache.Cache) *Server {
 	config := util.Config{
 		TokenSymmetricKey:   util.RandomString(32),
 		AccessTokenDuration: time.Minute,
+	}
+
+	if cache == nil {
+		cache = noopCache{}
 	}
 
 	server, err := NewServer(config, store, taskDistributor, cache)

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -3,13 +3,16 @@ package api
 import (
 	"errors"
 	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/MonitorAllen/nostalgia/internal/cache"
+	"github.com/MonitorAllen/nostalgia/internal/cache/key"
 	"github.com/MonitorAllen/nostalgia/token"
 	"github.com/MonitorAllen/nostalgia/util"
 	"github.com/gin-gonic/gin"
 	"github.com/h2non/filetype"
-	"net/http"
-	"slices"
-	"strings"
 )
 
 const (
@@ -18,7 +21,7 @@ const (
 	authorizationPayloadKey = "authorization_payload"
 )
 
-func authMiddleware(tokenMaker token.Maker) gin.HandlerFunc {
+func authMiddleware(tokenMaker token.Maker, c cache.Cache) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		authorizationHeader := ctx.GetHeader(authorizationHeaderKey)
 		if len(authorizationHeader) == 0 {
@@ -45,6 +48,13 @@ func authMiddleware(tokenMaker token.Maker) gin.HandlerFunc {
 		payload, err := tokenMaker.VerifyToken(accessToken)
 		if err != nil {
 			ctx.AbortWithStatusJSON(http.StatusUnauthorized, errorResponse(err))
+			return
+		}
+
+		// Check if user has been disabled after token was issued
+		var disabled bool
+		if found, _ := c.Get(ctx, key.GetUserDisabledKey(payload.UserID.String()), &disabled); found && disabled {
+			ctx.AbortWithStatusJSON(http.StatusForbidden, errorResponse(errors.New("account disabled")))
 			return
 		}
 

--- a/api/middleware_test.go
+++ b/api/middleware_test.go
@@ -2,15 +2,18 @@ package api
 
 import (
 	"fmt"
-	"github.com/MonitorAllen/nostalgia/token"
-	"github.com/MonitorAllen/nostalgia/util"
-	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	mockcache "github.com/MonitorAllen/nostalgia/internal/cache/mock"
+	"github.com/MonitorAllen/nostalgia/token"
+	"github.com/MonitorAllen/nostalgia/util"
+	"github.com/gin-gonic/gin"
+	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 )
 
 func addAuthorization(t *testing.T, request *http.Request, tokenMaker token.Maker, authorizationType string, userID uuid.UUID, username string, role string, duration time.Duration) {
@@ -78,16 +81,33 @@ func TestAuthMiddleware(t *testing.T) {
 		tc := testCases[i]
 
 		t.Run(tc.name, func(t *testing.T) {
-			server := newTestServer(t, nil, nil, nil)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			cache := mockcache.NewMockCache(ctrl)
+			// Disabled-user lookup returns "not found" (user is active) when reached
+			cache.EXPECT().
+				Get(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(false, nil).
+				AnyTimes()
+
+			server := newTestServer(t, nil, nil, cache)
 
 			authPath := "/auth"
 			server.router.GET(
-				authPath, authMiddleware(server.tokenMaker),
+				authPath, authMiddleware(server.tokenMaker, server.cache),
 				func(context *gin.Context) {
 					context.JSON(http.StatusOK, gin.H{})
 				},
 			)
 
+			recorder := httptest.NewRecorder()
+			request, err := http.NewRequest(http.MethodGet, authPath, nil)
+			require.NoError(t, err)
+
+			tc.setupAuth(t, request, server.tokenMaker)
+			server.router.ServeHTTP(recorder, request)
+			tc.checkResponse(t, recorder)
 		})
 	}
 }

--- a/api/server.go
+++ b/api/server.go
@@ -101,7 +101,7 @@ func (server *Server) setupRouter() {
 		public.GET("/categories/:id", server.getCategory)
 	}
 
-	authRoutes := router.Group("/api").Use(authMiddleware(server.tokenMaker))
+	authRoutes := router.Group("/api").Use(authMiddleware(server.tokenMaker, server.cache))
 	{
 		authRoutes.POST("/comments", server.createComment)
 		authRoutes.DELETE("/comments/:id", server.deleteComment)

--- a/api/user.go
+++ b/api/user.go
@@ -246,7 +246,23 @@ func (server *Server) renewAccessToken(ctx *gin.Context) {
 		return
 	}
 
-	accessToken, accessPayload, err := server.tokenMaker.CreateToken(refreshPayload.UserID, refreshPayload.Username, refreshPayload.Role, server.config.AccessTokenDuration)
+	// Check if user has been disabled since the refresh token was issued
+	user, err := server.store.GetUser(ctx, refreshPayload.UserID)
+	if err != nil {
+		if errors.Is(err, db.ErrRecordNotFound) {
+			ctx.JSON(http.StatusNotFound, errorResponse(fmt.Errorf("user not found")))
+			return
+		}
+		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		return
+	}
+	if user.DisabledAt.Valid {
+		ctx.JSON(http.StatusForbidden, errorResponse(fmt.Errorf("account disabled")))
+		return
+	}
+
+	// Use current role from DB, not stale role from refresh token
+	accessToken, accessPayload, err := server.tokenMaker.CreateToken(refreshPayload.UserID, refreshPayload.Username, user.Role, server.config.AccessTokenDuration)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
 		return

--- a/db/query/article.sql
+++ b/db/query/article.sql
@@ -134,6 +134,7 @@ FROM articles a
          LEFT JOIN users u on a.owner = u.id
 WHERE a.is_publish = COALESCE(sqlc.narg(is_publish), a.is_publish)
   AND a.category_id = COALESCE(sqlc.narg(category_id), a.category_id)
+  AND a.deleted_at = '0001-01-01 00:00:00Z'
 ORDER BY a.created_at DESC
 LIMIT $1 OFFSET $2;
 
@@ -141,7 +142,8 @@ LIMIT $1 OFFSET $2;
 SELECT count(*)
 FROM articles
 WHERE is_publish = COALESCE(sqlc.narg(is_publish), is_publish)
-  AND category_id = COALESCE(sqlc.narg(category_id), category_id);
+  AND category_id = COALESCE(sqlc.narg(category_id), category_id)
+  AND deleted_at = '0001-01-01 00:00:00Z';
 
 -- name: UpdateArticle :one
 UPDATE articles

--- a/db/query/category.sql
+++ b/db/query/category.sql
@@ -37,13 +37,14 @@ FROM
 WHERE
     category_id = $1
     AND is_publish = true
+    AND a.deleted_at = '0001-01-01 00:00:00Z'
 ORDER BY a.created_at DESC
 LIMIT $2
 OFFSET
     $3;
 
 -- name: CountArticlesByCategoryID :one
-SELECT count(*) FROM articles WHERE category_id = $1;
+SELECT count(*) FROM articles WHERE category_id = $1 AND deleted_at = '0001-01-01 00:00:00Z';
 
 -- name: GetCategory :one
 SELECT * FROM categories WHERE id = @id LIMIT 1;

--- a/db/sqlc/article.sql.go
+++ b/db/sqlc/article.sql.go
@@ -31,6 +31,7 @@ SELECT count(*)
 FROM articles
 WHERE is_publish = COALESCE($1, is_publish)
   AND category_id = COALESCE($2, category_id)
+  AND deleted_at = '0001-01-01 00:00:00Z'
 `
 
 type CountArticlesParams struct {
@@ -609,6 +610,7 @@ FROM articles a
          LEFT JOIN users u on a.owner = u.id
 WHERE a.is_publish = COALESCE($3, a.is_publish)
   AND a.category_id = COALESCE($4, a.category_id)
+  AND a.deleted_at = '0001-01-01 00:00:00Z'
 ORDER BY a.created_at DESC
 LIMIT $1 OFFSET $2
 `

--- a/db/sqlc/category.sql.go
+++ b/db/sqlc/category.sql.go
@@ -14,7 +14,7 @@ import (
 )
 
 const countArticlesByCategoryID = `-- name: CountArticlesByCategoryID :one
-SELECT count(*) FROM articles WHERE category_id = $1
+SELECT count(*) FROM articles WHERE category_id = $1 AND deleted_at = '0001-01-01 00:00:00Z'
 `
 
 func (q *Queries) CountArticlesByCategoryID(ctx context.Context, categoryID int64) (int64, error) {
@@ -134,6 +134,7 @@ FROM
 WHERE
     category_id = $1
     AND is_publish = true
+    AND a.deleted_at = '0001-01-01 00:00:00Z'
 ORDER BY a.created_at DESC
 LIMIT $2
 OFFSET

--- a/gapi/authorization.go
+++ b/gapi/authorization.go
@@ -3,12 +3,14 @@ package gapi
 import (
 	"context"
 	"fmt"
+	"strings"
+
+	"github.com/MonitorAllen/nostalgia/internal/cache/key"
 	"github.com/MonitorAllen/nostalgia/token"
 	"github.com/MonitorAllen/nostalgia/util"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
-	"strings"
 )
 
 const (
@@ -45,6 +47,12 @@ func (server *Server) authorizeAdmin(ctx context.Context) (*token.Payload, strin
 	}
 	if payload.Role != util.Admin {
 		return nil, "", status.Error(codes.PermissionDenied, "admin role required")
+	}
+
+	// Check if user has been disabled
+	var disabled bool
+	if found, _ := server.cache.Get(ctx, key.GetUserDisabledKey(payload.UserID.String()), &disabled); found && disabled {
+		return nil, "", status.Error(codes.PermissionDenied, "account disabled")
 	}
 
 	return payload, accessToken, nil

--- a/gapi/main_test.go
+++ b/gapi/main_test.go
@@ -33,10 +33,29 @@ func newGAPITestStore(store *mockdb.MockStore) db.Store {
 	return &testStore{MockStore: store}
 }
 
+// noopCache is a cache that stores nothing — Get always reports "not found".
+// Used as a default for tests that don't exercise cache behaviour.
+type noopCache struct{}
+
+func (noopCache) Ping(context.Context) error                                  { return nil }
+func (noopCache) Get(context.Context, string, any) (bool, error)              { return false, nil }
+func (noopCache) Set(context.Context, string, any, time.Duration) error       { return nil }
+func (noopCache) Del(context.Context, string) error                           { return nil }
+func (noopCache) SetNX(context.Context, string, any, time.Duration) (bool, error) {
+	return true, nil
+}
+func (noopCache) Incr(context.Context, string) (int64, error)      { return 0, nil }
+func (noopCache) IsExpired(context.Context, string) (bool, error)  { return false, nil }
+func (noopCache) Close() error                                     { return nil }
+
 func newTestServer(t *testing.T, store db.Store, taskDistributor worker.TaskDistributor, cache cache.Cache) *Server {
 	config := util.Config{
 		TokenSymmetricKey:   util.RandomString(32),
 		AccessTokenDuration: time.Minute,
+	}
+
+	if cache == nil {
+		cache = noopCache{}
 	}
 
 	server, err := NewServer(config, store, taskDistributor, cache)

--- a/gapi/rpc_delete_article_test.go
+++ b/gapi/rpc_delete_article_test.go
@@ -34,6 +34,12 @@ func TestDeleteArticleInvalidatesDetailAndListCaches(t *testing.T) {
 	taskDistributor := mockwk.NewMockTaskDistributor(ctrl)
 	redisCache := mockcache.NewMockCache(ctrl)
 
+	// authorizeAdmin checks the disabled-user flag; report "active"
+	redisCache.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(false, nil).
+		AnyTimes()
+
 	store.EXPECT().GetArticle(gomock.Any(), gomock.Eq(articleID)).Times(1).Return(article, nil)
 	taskDistributor.EXPECT().
 		DistributeTaskDelayDeleteCacheDefault(

--- a/gapi/rpc_disable_user.go
+++ b/gapi/rpc_disable_user.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	db "github.com/MonitorAllen/nostalgia/db/sqlc"
+	"github.com/MonitorAllen/nostalgia/internal/cache/key"
 	"github.com/MonitorAllen/nostalgia/pb"
 	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
@@ -33,6 +34,9 @@ func (server *Server) DisableUser(ctx context.Context, req *pb.DisableUserReques
 		}
 		return nil, status.Errorf(codes.Internal, "failed to disable user: %v", err)
 	}
+
+	// Mark user as disabled in cache so active tokens are rejected
+	_ = server.cache.Set(ctx, key.GetUserDisabledKey(id.String()), true, 0)
 
 	return &pb.DisableUserResponse{User: convertUser(result.User)}, nil
 }

--- a/gapi/rpc_enable_user.go
+++ b/gapi/rpc_enable_user.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	db "github.com/MonitorAllen/nostalgia/db/sqlc"
+	"github.com/MonitorAllen/nostalgia/internal/cache/key"
 	"github.com/MonitorAllen/nostalgia/pb"
 	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
@@ -29,6 +30,9 @@ func (server *Server) EnableUser(ctx context.Context, req *pb.EnableUserRequest)
 		}
 		return nil, status.Errorf(codes.Internal, "failed to enable user: %v", err)
 	}
+
+	// Remove disabled flag from cache so user can use tokens again
+	_ = server.cache.Del(ctx, key.GetUserDisabledKey(id.String()))
 
 	return &pb.EnableUserResponse{User: convertUser(user)}, nil
 }

--- a/gapi/rpc_update_article_test.go
+++ b/gapi/rpc_update_article_test.go
@@ -47,6 +47,12 @@ func TestUpdateArticleInvalidatesDetailAndListCaches(t *testing.T) {
 	taskDistributor := mockwk.NewMockTaskDistributor(ctrl)
 	redisCache := mockcache.NewMockCache(ctrl)
 
+	// authorizeAdmin checks the disabled-user flag; report "active"
+	redisCache.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(false, nil).
+		AnyTimes()
+
 	store.EXPECT().GetArticle(gomock.Any(), gomock.Eq(articleID)).Times(1).Return(previousArticle, nil)
 	taskDistributor.EXPECT().
 		DistributeTaskDelayDeleteCacheDefault(
@@ -95,6 +101,12 @@ func TestUpdateArticleRejectsVisitorBeforeInvalidatingCache(t *testing.T) {
 	store := mockdb.NewMockStore(ctrl)
 	taskDistributor := mockwk.NewMockTaskDistributor(ctrl)
 	redisCache := mockcache.NewMockCache(ctrl)
+
+	// authorizeAdmin checks the disabled-user flag; report "active"
+	redisCache.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(false, nil).
+		AnyTimes()
 
 	store.EXPECT().GetArticle(gomock.Any(), gomock.Any()).Times(0)
 	store.EXPECT().UpdateArticleTx(gomock.Any(), gomock.Any()).Times(0)

--- a/internal/cache/key/user.go
+++ b/internal/cache/key/user.go
@@ -1,9 +1,18 @@
 package key
 
+import "fmt"
+
 const (
 	UserContributionsKey = "cache:user:contributions"
+	UserDisabledPrefix   = "cache:user:disabled:"
 )
 
 func GetUserContributionsKey() string {
 	return UserContributionsKey
+}
+
+// GetUserDisabledKey returns the cache key for a disabled user flag.
+// Presence of this key means the user is disabled.
+func GetUserDisabledKey(userID string) string {
+	return fmt.Sprintf("%s%s", UserDisabledPrefix, userID)
 }

--- a/main.go
+++ b/main.go
@@ -116,7 +116,7 @@ func runDBMigration(migrationURL string, dbSource string) {
 
 func runTaskProcessor(ctx context.Context, waitGroup *errgroup.Group, config util.Config, redisOpt asynq.RedisClientOpt, store db.Store, cache cache.Cache) {
 	mailer := mail.NewGmailSender(config.EmailSenderName, config.EmailSenderAddress, config.EmailSenderPassword)
-	taskProcessor := worker.NewRedisTaskProcessor(redisOpt, store, cache, mailer)
+	taskProcessor := worker.NewRedisTaskProcessor(redisOpt, store, cache, mailer, config)
 	log.Info().Msg("start task processor")
 	err := taskProcessor.Start()
 	if err != nil {

--- a/worker/processor.go
+++ b/worker/processor.go
@@ -6,6 +6,7 @@ import (
 	db "github.com/MonitorAllen/nostalgia/db/sqlc"
 	"github.com/MonitorAllen/nostalgia/internal/cache"
 	"github.com/MonitorAllen/nostalgia/mail"
+	"github.com/MonitorAllen/nostalgia/util"
 	"github.com/hibiken/asynq"
 	"github.com/redis/go-redis/v9"
 	"github.com/rs/zerolog/log"
@@ -24,6 +25,7 @@ type RedisTaskProcessor struct {
 	store  db.Store
 	cache  cache.Cache
 	mailer mail.EmailSender
+	config util.Config
 }
 
 const (
@@ -31,7 +33,7 @@ const (
 	QueueDefault  = "default"
 )
 
-func NewRedisTaskProcessor(redisOpt asynq.RedisClientOpt, store db.Store, cache cache.Cache, mailer mail.EmailSender) TaskProcessor {
+func NewRedisTaskProcessor(redisOpt asynq.RedisClientOpt, store db.Store, cache cache.Cache, mailer mail.EmailSender, config util.Config) TaskProcessor {
 	logger := NewLogger()
 	redis.SetLogger(logger)
 
@@ -55,6 +57,7 @@ func NewRedisTaskProcessor(redisOpt asynq.RedisClientOpt, store db.Store, cache 
 		store:  store,
 		cache:  cache,
 		mailer: mailer,
+		config: config,
 	}
 }
 

--- a/worker/task_notify_automation_draft.go
+++ b/worker/task_notify_automation_draft.go
@@ -79,7 +79,7 @@ func buildAutomationDraftEmail(payload PayloadNotifyAutomationDraft) (string, st
 分类：%s<br/>
 模型：%s<br/>
 幂等键：%s<br/>
-审核入口：<a target="blank" href="%s">%s</a><br/>`,
+审核入口：<a target="_blank" href="%s">%s</a><br/>`,
 			payload.Title,
 			payload.CategoryName,
 			payload.GenerationModel,

--- a/worker/task_send_verify_email.go
+++ b/worker/task_send_verify_email.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	db "github.com/MonitorAllen/nostalgia/db/sqlc"
 	"github.com/MonitorAllen/nostalgia/util"
@@ -59,12 +60,16 @@ func (processor *RedisTaskProcessor) ProcessTaskSendVerifyEmail(ctx context.Cont
 		Email:      user.Email,
 		SecretCode: util.RandomString(32),
 	})
+	if err != nil {
+		return fmt.Errorf("failed to create verify email: %w", err)
+	}
 
 	subject := "Welcome to Nostalgia"
-	verifyUrl := fmt.Sprintf("http://localhost:3000/auth/verifyEmail/%d/%s", verifyEmail.ID, verifyEmail.SecretCode)
+	baseURL := strings.TrimRight(processor.config.Domain, "/")
+	verifyUrl := fmt.Sprintf("%s/auth/verifyEmail/%d/%s", baseURL, verifyEmail.ID, verifyEmail.SecretCode)
 	content := fmt.Sprintf(`Hello %s,<br/>
 	Thank you for registering with us!<br/>
-	Please <a target="blank" href="%s">click here</a> to verify your email address.<br/>`, user.FullName, verifyUrl)
+	Please <a target="_blank" href="%s">click here</a> to verify your email address.<br/>`, user.FullName, verifyUrl)
 	to := []string{user.Email}
 	err = processor.mailer.SendEmail(subject, content, to, nil, nil, nil)
 	if err != nil {


### PR DESCRIPTION
## 概述

修复全量代码审计发现的 P1 认证与数据完整性问题。

## 修复内容

### 1. 禁用用户仍可使用有效 Token 访问
- 原问题：禁用功能只在 login 入口拦截，已发放的 access token 直到过期前仍有效；`renewAccessToken` 也只检查 `session.IsBlocked`，禁用用户可持续续签。
- 方案：引入 Redis key `user:disabled:{userID}`，`DisableUser`/`EnableUser` 时 set/del。
- Gin `authMiddleware` 与 gRPC `authorizeAdmin` 在 token 验证后检查该 key，命中则拒绝。
- `renewAccessToken` 增加禁用状态检查，并改为从 DB 读取当前 role（修复角色变更后旧 role 仍随 token 下发的问题）。

### 2. 验证邮件链接硬编码 localhost
- `worker/task_send_verify_email.go`：原链接硬编码 `http://localhost:3000`，生产环境不可达。
- 给 task processor 注入 `Config`，复用已有 `Domain` 字段构建链接。
- 顺带修复 `CreateVerifyEmail` error 未检查、`target="blank"` → `target="_blank"`（含 automation draft 通知）。

### 3. 公开 API 返回已软删除文章
- `ListArticles`、`CountArticles`、`ListArticlesByCategoryID`、`CountArticlesByCategoryID` 缺少 `deleted_at` 过滤。
- 补齐过滤条件（与 `SearchArticles` 一致），`make sqlc` 重新生成。

## 测试
- 重写 `middleware_test.go`，使其真正执行 `ServeHTTP`（修复审计指出的"测试从未发请求"问题）。
- gapi 测试为 `authorizeAdmin` 的禁用检查补充 mock 期望，nil cache 调用点改用 noop cache 默认值。
- `make test` 全量通过。

## 注意
禁用拦截依赖 Redis key 同步，当前仅 `DisableUser`/`EnableUser` 两个 RPC 会维护该 key；若未来新增绕过这两个 RPC 直改 DB 的路径，需同步该缓存。

🤖 Generated with [Claude Code](https://claude.com/claude-code)